### PR TITLE
fix: PREV-70 - Rotate logs daily

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -14,7 +14,7 @@ from app.core.routers import image, health, pdf, document
 
 app = FastAPI(
     title=service.NAME,
-    version="0.2.8",
+    version="0.2.9",
     description=service.DESCRIPTION,
 )
 

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -173,10 +173,12 @@ LOGGING_CONFIG = {
             "formatter": "syslog",
         },
         "file_standard": {
-            "class": "logging.handlers.RotatingFileHandler",
+            "class": "logging.handlers.TimedRotatingFileHandler",
             "filename": log_path,
             "formatter": "syslog",
             "encoding": "utf8",
+            "when": "d",
+            "backupCount": 50,
         },
         "console_gunicorn": {
             "class": "logging.StreamHandler",
@@ -184,10 +186,12 @@ LOGGING_CONFIG = {
             "formatter": "syslog",
         },
         "file_gunicorn": {
-            "class": "logging.handlers.RotatingFileHandler",
+            "class": "logging.handlers.TimedRotatingFileHandler",
             "filename": log_path,
             "formatter": "syslog",
             "encoding": "utf8",
+            "when": "d",
+            "backupCount": 50,
         },
     },
     "formatters": {

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -3,8 +3,8 @@ targets=(
    "ubuntu"
 )
 pkgname="carbonio-preview-ce"
-pkgver="0.2.8"
-pkgrel="2"
+pkgver="0.2.9"
+pkgrel="1"
 pkgdesc="Carbonio Preview"
 pkgdesclong=(
    "Carbonio Preview"


### PR DESCRIPTION
Logs are written in a single file and it can leads to problem in future. We need to split logs into different files.
This can be done using TimedRotatingFileHandler with when = daily and backupCount = 50