### PR TITLE
fix: PREV-72 - Thumbnail generation goes in timeout

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!--
+SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
+# Description
+
+Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+## Type of change
+
+Please delete options that are not relevant or put an 'x' on the desired options.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+# Checklist:
+
+This checklist is used as a reminder to avoid half-baked code
+- [ ] The PR title follows the following structure:" type[optional scope]: PREV-XX - LONG DESCRIPTION "
+- [ ] I have correctly installed and enabled pre-commit
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] If I have introduced new dependencies I have added them to the pre-commit unittest additional_dependencies AND to the THIRDPARTIES file

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,6 +20,7 @@ Please delete options that are not relevant or put an 'x' on the desired options
 
 This checklist is used as a reminder to avoid half-baked code
 - [ ] The PR title follows the following structure:" type[optional scope]: PREV-XX - LONG DESCRIPTION "
+- [ ] I have bumped both the PKGBUILD version and controller version, and they are the same.
 - [ ] I have correctly installed and enabled pre-commit
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
         entry: python -m unittest discover
         language: python
         additional_dependencies: [
-            python-multipart, FastAPI, uvicorn, gunicorn, Pillow, pdfrw, responses, psutil
+            python-multipart, FastAPI, uvicorn, gunicorn, Pillow, pdfrw, responses, psutil, pypdfium2
         ]
         'types': [python]
         pass_filenames: false

--- a/THIRDPARTIES
+++ b/THIRDPARTIES
@@ -219,6 +219,7 @@ pypdfium2;
 BSD 3-Clause License (BSD-3-Clause) applies to:
 
 uvicorn, 2017, Copyright Encode OSS Ltd;
+psutil, 2009, Copyright Jay Loden, Dave Daeschler, Giampaolo Rodola';
 PyPDF2
 2006-2008, Copyright Mathieu Fenniak,
 2007, Some contributions copyright Ashish Kulkarni <kulkarni.ashish@gmail.com>,

--- a/THIRDPARTIES
+++ b/THIRDPARTIES
@@ -9,6 +9,7 @@ python-multipart, 2012, Copyright Andrew Dunham;
 responses, 2015, Copyright David Cramer;
 bandit;
 requests;
+pypdfium2;
 
 
                                  Apache License

--- a/app/core/services/document_manipulation/document_manipulation.py
+++ b/app/core/services/document_manipulation/document_manipulation.py
@@ -152,6 +152,11 @@ async def convert_pdf_to_image(
             output_extension,
             False,
             ImageQualityEnum.HIGHEST.get_jpeg_int_quality(),
+            # the render is automatically done at the highest quality.
+            # The desired quality will be set while processing the image
+            # at the end of the api call because
+            # doing it here will just increase method parameters and complexity,
+            # without major performance improvements
         )
     except pypdfium2.PdfiumError as e:
         log.info(f"Wrong pdf file passed, error: {e}")

--- a/app/core/services/document_manipulation/document_manipulation.py
+++ b/app/core/services/document_manipulation/document_manipulation.py
@@ -4,13 +4,18 @@
 import io
 import logging
 import sys
+import pypdfium2
+
 from typing import IO, Optional
 
 from pdfrw import PdfReader, PdfWriter
 from pdfrw.errors import PdfParseError
+from starlette.exceptions import HTTPException
 
 from app.core.resources import libre_office_handler
 from app.core.resources.constants import service
+from app.core.resources.schemas.enums.image_quality_enum import ImageQualityEnum
+from app.core.services.image_manipulation import image_manipulation
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +31,7 @@ def split_pdf(
     :param last_page_number: last page to convert
     :return: pdf with the first n pages
     """
-    raw_content = content.read()
+    raw_content: bytes = content.read()
     pdf: PdfReader = _parse_if_valid_pdf(raw_content)
     if not pdf:
         return _write_pdf_to_buffer(None)  # returns empty pdf
@@ -125,6 +130,32 @@ async def convert_file_to(
     return await _convert_with_libre(
         content=content, output_extension=output_extension, log=log
     )
+
+
+async def convert_pdf_to_image(
+    content: IO, output_extension: str, page_number: int, log: logging = logger
+) -> io.BytesIO:
+    """
+    Converts pdf to any image supported format using PDFium
+    \f
+    :param content: pdf to convert
+    :param output_extension: desired file output type
+    :param page_number: first page to convert
+    :param log: logger to use
+    """
+    try:
+        pdf = pypdfium2.PdfDocument(content)
+        page = pdf.get_page(page_number)
+        pil_image = page.render_topil()
+        return image_manipulation.save_image_to_buffer(
+            pil_image,
+            output_extension,
+            False,
+            ImageQualityEnum.HIGHEST.get_jpeg_int_quality(),
+        )
+    except pypdfium2.PdfiumError as e:
+        log.info(f"Wrong pdf file passed, error: {e}")
+        raise HTTPException(status_code=400, detail="Invalid pdf file")
 
 
 async def convert_pdf_to(

--- a/app/core/services/pdf_service.py
+++ b/app/core/services/pdf_service.py
@@ -74,11 +74,10 @@ async def create_thumbnail_from_raw(file: UploadFile, output_format: str) -> io.
     :param file: uploaded pdf to convert
     :param output_format: the image type that the thumbnail will have
     """
-    return await document_manipulation.convert_pdf_to(
-        content=file.file,
+    return await document_manipulation.convert_pdf_to_image(
+        content=file.file.read(),  # file.file,
         output_extension=output_format,
-        first_page_number=1,
-        last_page_number=1,
+        page_number=0,
     )
 
 
@@ -107,11 +106,10 @@ async def retrieve_pdf_and_create_thumbnail(
     else:
         return Response(
             content=(
-                await document_manipulation.convert_pdf_to(
+                await document_manipulation.convert_pdf_to_image(
                     content=io.BytesIO(response_data.content),
                     output_extension=output_format,
-                    first_page_number=1,
-                    last_page_number=1,
+                    page_number=0,
                 )
             ).read(),
             media_type=f"image/{output_format}",

--- a/app/core/services/pdf_service.py
+++ b/app/core/services/pdf_service.py
@@ -75,7 +75,7 @@ async def create_thumbnail_from_raw(file: UploadFile, output_format: str) -> io.
     :param output_format: the image type that the thumbnail will have
     """
     return await document_manipulation.convert_pdf_to_image(
-        content=file.file.read(),  # file.file,
+        content=file.file.read(),
         output_extension=output_format,
         page_number=0,
     )

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -4,7 +4,7 @@ targets=(
 )
 pkgname="carbonio-preview-ce"
 pkgver="0.2.9"
-pkgrel="2"
+pkgrel="3"
 pkgdesc="Carbonio Preview"
 pkgdesclong=(
   "Carbonio Preview"

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ requests~=2.27.1
 
 Pillow~=9.0.0
 pdfrw~=0.4
+pypdfium2~=2.5.0
 
 unoserver==1.1
 psutil==5.9.0


### PR DESCRIPTION
# Description

Thumbnail generation with specific PDFs caused the request to the preview service to go in timeout. This was caused by LibreOffice taking minutes to convert multi layered or simply resource heavy PDFs. This problem was tested and reproduced even calling the LibreOffice command line utilities. 

To fix this problem it was decided to relived LibreOffice from some load and use another dependency to handle PDFs -> Image conversion. PDFium was chosen, more specifically pypdfium2. This library is also faster and more resource efficient.

It was also added a template model for the next PR to follow strictly 

## Type of change

Please delete options that are not relevant or put an 'x' on the desired options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
# Checklist:

This checklist is used as a reminder to avoid half-baked code
- [x] The PR title follows the following structure:" type[optional scope]: PREV-XX - LONG DESCRIPTION "
- [x] I have correctly installed and enabled pre-commit
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] If I have introduced new dependencies I have added them to the pre-commit unittest additional_dependencies AND to the THIRDPARTIES file