### PR TITLE
fix: PREV-80 - add missing group at user creation

### DIFF
--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -136,6 +136,7 @@ postinst() {
   getent passwd 'carbonio-preview' >/dev/null ||
     useradd -r -m \
       -d '/var/lib/carbonio-preview' \
+      -g 'carbonio-preview' \
       -s /sbin/nologin 'carbonio-preview'
 
   chown carbonio-preview:carbonio-preview -R "/var/log/carbonio/preview"


### PR DESCRIPTION
During the postinst stage the useradd command create user without the related group.
Adding missing `-g` flag fix this behaviour