### PR TITLE
chore: IN-497 - add missing rhel8 provides

### DIFF
--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -46,6 +46,15 @@ makedepends:apt=(
   "python3-pip"
 )
 
+provides:yum=(
+  "libjpeg-62ed1500.so.62.3.0(LIBJPEG_6.2)(64bit)"
+  "liblzma-d540a118.so.5.2.5(XZ_5.0)(64bit)"
+  "libpng16-213e245f.so.16.37.0(PNG16_0)(64bit)"
+  "libz-dd453c56.so.1.2.11(ZLIB_1.2.3.4)(64bit)"
+  "libz-dd453c56.so.1.2.11(ZLIB_1.2.9)(64bit)"
+  "/bin/python3"
+)
+
 sources=(
   "carbonio-preview.service"
   "carbonio-preview-sidecar.service"


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com

SPDX-License-Identifier: AGPL-3.0-only
-->

# Description

because of some libraries (.so) found under the fakeroot, rpm automatically generate 'Requires:' using unresolvable symbols.
This lead to a failing installation on RHEL8 OSes

## Type of change

Please delete options that are not relevant or put an 'x' on the desired options.

- Bug fix (non-breaking change which fixes an issue)

Add 'Provides:' for yum in order to solve libraries symbols automatically generated by rpm at build time

**NOTE**: I should bump at least the `pkgrel` field. Let me know if you require to provide this as hotfix 