### PR TITLE
fix: PREV-85 - Add libre office watchdog

### DIFF
--- a/app/core/resources/libre_office_handler.py
+++ b/app/core/resources/libre_office_handler.py
@@ -75,7 +75,7 @@ def watchdog_threaded_function():
                 f"LibreOffice is offline at ip: {IP} and port: {libre_port},"
                 f" restarting worker .."
             )
-            shutdown_worker()
+            shutdown_worker(exit_code=10)
         else:
             logger.debug(
                 f"LibreOffice is working at ip: {IP} and port: {libre_port},"
@@ -97,21 +97,23 @@ def init_signals():
     signal.signal(signal.SIGHUP, shutdown_worker)
 
 
-def shutdown_worker(signal_number=6, caller=None):
+def shutdown_worker(signal_number=6, caller=None, exit_code: int = 1):
     """
     Shuts down LibreOffice worker instance and current worker.
     \f
     :param signal_number: number representing signal received (example 6 = Abort)
     :param caller: function that made the signal fire
+    :param exit_code: return code used for debugging
     :return: True if the service booted up correctly
     """
     logger.warning(
-        f"Shut down worker called from {caller} with signal number {signal_number}"
+        f"Shut down worker called from {caller} with"
+        f" signal number {signal_number} and exit code {exit_code}"
     )
     _shutdown_libre_instance()
     logging.shutdown()
     executor.shutdown()
-    os._exit(1)
+    os._exit(exit_code)
 
 
 def _shutdown_libre_instance():

--- a/app/core/resources/libre_office_handler.py
+++ b/app/core/resources/libre_office_handler.py
@@ -133,6 +133,7 @@ def is_libre_instance_up(timeout: int = 5) -> bool:
     """
     method that checks if the worker instances of unoserver is up and running
     \f
+    :param timeout: seconds to wait for a response from LibreOffice
     :return: True if the instance is working
     """
     if type(UnoConverter) != ImportError:


### PR DESCRIPTION
# Description

LibreOffice didn't reboot correctly after crashing, it only rebooted if LibreOffice convert timed out. What we did is create a thread that periodically checks if the service is up and if it's not then it will reboot the whole worker.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

This checklist is used as a reminder to avoid half-baked code
- [x] The PR title follows the following structure:" type[optional scope]: PREV-XX - LONG DESCRIPTION "
- [ ] I have bumped both the PKGBUILD version and controller version, and they are the same.
- [x] I have correctly installed and enabled pre-commit
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] If I have introduced new dependencies I have added them to the pre-commit unittest additional_dependencies AND to the THIRDPARTIES file