### PR TITLE
fix: PREV-63 - Rotate image with EXIF metadata

### DIFF
--- a/app/controller.py
+++ b/app/controller.py
@@ -14,7 +14,7 @@ from app.core.routers import image, health, pdf, document
 
 app = FastAPI(
     title=service.NAME,
-    version="0.2.10",
+    version="0.2.11",
     description=service.DESCRIPTION,
 )
 

--- a/app/core/resources/libre_office_handler.py
+++ b/app/core/resources/libre_office_handler.py
@@ -75,7 +75,7 @@ def watchdog_threaded_function():
                 f"LibreOffice is offline at ip: {IP} and port: {libre_port},"
                 f" restarting worker .."
             )
-            shutdown_worker()
+            shutdown_worker(exit_code=10)
         else:
             logger.debug(
                 f"LibreOffice is working at ip: {IP} and port: {libre_port},"
@@ -97,21 +97,23 @@ def init_signals():
     signal.signal(signal.SIGHUP, shutdown_worker)
 
 
-def shutdown_worker(signal_number=6, caller=None):
+def shutdown_worker(signal_number=6, caller=None, exit_code: int = 1):
     """
     Shuts down LibreOffice worker instance and current worker.
     \f
     :param signal_number: number representing signal received (example 6 = Abort)
     :param caller: function that made the signal fire
+    :param exit_code: return code used for debugging
     :return: True if the service booted up correctly
     """
     logger.warning(
-        f"Shut down worker called from {caller} with signal number {signal_number}"
+        f"Shut down worker called from {caller} with"
+        f" signal number {signal_number} and exit code {exit_code}"
     )
     _shutdown_libre_instance()
     logging.shutdown()
     executor.shutdown()
-    os._exit(1)
+    os._exit(exit_code)
 
 
 def _shutdown_libre_instance():

--- a/app/core/services/image_manipulation/image_manipulation.py
+++ b/app/core/services/image_manipulation/image_manipulation.py
@@ -26,7 +26,8 @@ def save_image_to_buffer(
 ) -> io.BytesIO:
     """
     Saves the given image object to a buffer object,
-    converting to the given format and to the given quality
+    converting to the given format and to the given quality and rotated
+    according to EXIF metadata
     \f
     :param img: img to convert and save
     :param _format: format to save to
@@ -299,7 +300,7 @@ def _convert_requested_size_to_true_res_to_scale(
 
 def _parse_to_valid_image(content: io.BytesIO):
     """
-    Parses an image into a valid Pil Image,
+    Parses an image into a valid Pil Image rotating it according to EXIF metadata,
     if the image is empty returns empty MinxMin RGB image
     \f
     :param content: Image to parse

--- a/app/core/services/image_manipulation/image_manipulation.py
+++ b/app/core/services/image_manipulation/image_manipulation.py
@@ -36,6 +36,7 @@ def save_image_to_buffer(
     :return: buffer pointing at the start of the file, containing raw image
     """
     buffer = io.BytesIO()
+    img = ImageOps.exif_transpose(img)
     img.save(buffer, format=_format, optimize=_optimize, quality=_quality_value)
     buffer.seek(0)
     log.debug("PIL Image successfully saved to buffer.")
@@ -305,7 +306,8 @@ def _parse_to_valid_image(content: io.BytesIO):
     :return parsed image or new empty image
     """
     try:
-        return Image.open(content)
+        img = Image.open(content)
+        return ImageOps.exif_transpose(img)
     except PIL.UnidentifiedImageError as e:
         logger.debug(f"Invalid or empty image caused error: {e}")
         return Image.new("RGB", (consts.MINIMUM_RESOLUTION, consts.MINIMUM_RESOLUTION))

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -3,7 +3,7 @@ targets=(
    "ubuntu"
 )
 pkgname="carbonio-preview-ce"
-pkgver="0.2.10"
+pkgver="0.2.11"
 pkgrel="1"
 pkgdesc="Carbonio Preview"
 pkgdesclong=(

--- a/tests/core/services/image_manipulation/test_image_manipulation.py
+++ b/tests/core/services/image_manipulation/test_image_manipulation.py
@@ -5,6 +5,8 @@ import io
 import unittest
 from unittest.mock import MagicMock, patch
 
+from PIL import ImageOps
+
 from app.core.resources.schemas.enums.vertical_crop_position_enum import (
     VerticalCropPositionEnum,
 )
@@ -30,6 +32,7 @@ class TestImageManipulation(unittest.TestCase):
     def test_save_image_to_buffer(self):
         img_to_save = MagicMock()
         img_to_save.save = MagicMock()
+        ImageOps.exif_transpose = MagicMock(return_value=img_to_save)
         buffer = image_manipulation.save_image_to_buffer(img_to_save)
         self.assertEqual(1, img_to_save.save.call_count)
         self.assertEqual([], buffer.readlines())


### PR DESCRIPTION
# Description

Images were not rotated accordingly to EXIF metadata. We now rotate both when loading the image and when saving it (once it is transposed it deletes the EXIF metadata so it won't be rotated twice)

## Type of change

Please delete options that are not relevant or put an 'x' on the desired options.

- [x] Bug fix (non-breaking change which fixes an issue)
# Checklist:

This checklist is used as a reminder to avoid half-baked code
- [x] The PR title follows the following structure:" type[optional scope]: PREV-XX - LONG DESCRIPTION "
- [ ] I have bumped both the PKGBUILD version and controller version, and they are the same.
- [x] I have correctly installed and enabled pre-commit
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] If I have introduced new dependencies I have added them to the pre-commit unittest additional_dependencies AND to the THIRDPARTIES file