### PR TITLE
fix: PREV-95 - Kill Docs-Core process 

### DIFF
--- a/app/core/services/document_manipulation/document_manipulation.py
+++ b/app/core/services/document_manipulation/document_manipulation.py
@@ -221,8 +221,8 @@ async def _convert_with_libre(
         logger.warning(f"LibreOffice is not responding.. error {time_error}")
         sys.exit(1)
     except Exception as e:
-        logger.debug(
-            f"File to convert was empty, libre conversion failed with error {e}"
+        logger.info(
+            f"File to convert was corrupted, libre conversion failed with error {e}"
         )
 
     return out_data

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -21,8 +21,8 @@ spec:
   providesApis:
     - carbonio-preview-ce-rest-api
   dependsOn:
-    - carbonio-storages-ce
-    - carbonio-storages-ce-java-sdk
+    - component: carbonio-storages-ce
+    - component: carbonio-storages-ce-java-sdk
 
 ---
 


### PR DESCRIPTION
Co-authored-by: Federico Rispo <federico.rispo@zextras.com>

# Description

The carbonio-preview service is unable to kill docs-core and after some tries it crashes. This usually happens when the docs-core process takes 100% of the CPU and never releases the resources.
Kill parent process, augment logs regarding decs-core, update catalog-info.yaml

## Type of change

Please delete options that are not relevant or put an 'x' on the desired options.
- [x] Bug fix (non-breaking change which fixes an issue)
# Checklist:

This checklist is used as a reminder to avoid half-baked code
- [x] The PR title follows the following structure:" type[optional scope]: PREV-XX - LONG DESCRIPTION "
- [ ] I have bumped both the PKGBUILD version and controller version, and they are the same.
- [x] I have correctly installed and enabled pre-commit
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] If I have introduced new dependencies I have added them to the pre-commit unittest additional_dependencies AND to the THIRDPARTIES file