### PR TITLE
feat: PREV-96 - Disable Docs-Core via config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,39 +4,39 @@
 
 repos:
 -   repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v1.2.0
+    rev: v2.1.1
     hooks:
     -   id: conventional-pre-commit
         stages: [commit-msg]
         args: []
 
 -   repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v1.6.0
+    rev: v2.0.0
     hooks:
     -   id: autopep8
         language_version: python3.8
 
 -   repo: https://github.com/python/black.git
-    rev: 22.1.0
+    rev: 22.10.0
     hooks:
       - id: black
         language_version: python3.8
 
 -   repo: https://github.com/PyCQA/bandit
-    rev: 1.7.3
+    rev: 1.7.4
     hooks:
     -   id: bandit
         language_version: python3.8
 
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 4.0.1
+-   repo: https://github.com/pyCQA/flake8
+    rev: 6.0.0
     hooks:
     - id: flake8
       exclude: ^tests/
       language_version: python3.8
 
 -   repo: https://github.com/fsfe/reuse-tool
-    rev: v0.14.0
+    rev: v1.0.0
     hooks:
         - id: reuse
           exclude: Dockerfile

--- a/app/core/resources/config_loader.py
+++ b/app/core/resources/config_loader.py
@@ -4,7 +4,7 @@
 
 import configparser
 import os
-from typing import List
+from typing import List, Any
 
 config = configparser.ConfigParser()
 message_config = configparser.ConfigParser()
@@ -35,8 +35,13 @@ load_config()
 load_message_config()
 
 
-def read_config(section: str, value: str, raw: bool = False) -> str:
-    return config.get(section, value, raw=raw)
+def read_config(
+    section: str, value: str, raw: bool = False, default_value: Any = None
+) -> str:
+    if default_value:
+        return config.get(section, value, raw=raw, fallback=default_value)
+    else:
+        return config.get(section, value, raw=raw)
 
 
 def read_message_config(section: str, value: str, raw: bool = False) -> str:

--- a/app/core/resources/constants/message.py
+++ b/app/core/resources/constants/message.py
@@ -56,3 +56,11 @@ FORMAT_NOT_SUPPORTED_ERROR: str = read_message_config(
 FILE_NOT_VALID_ERROR: str = read_message_config(
     section=_validation_section_name, value="file_not_valid_error"
 )
+
+DOCUMENT_THUMBNAIL_NOT_ENABLED_ERROR: str = read_message_config(
+    section=_validation_section_name, value="document_thumbnail_not_enabled_error"
+)
+
+DOCUMENT_PREVIEW_NOT_ENABLED_ERROR: str = read_message_config(
+    section=_validation_section_name, value="document_preview_not_enabled_error"
+)

--- a/app/core/resources/constants/service.py
+++ b/app/core/resources/constants/service.py
@@ -30,7 +30,7 @@ ENABLE_DOCUMENT_PREVIEW = (
     if read_config(
         section=_service_section_name,
         value="enable_document_preview",
-        default_value="false",
+        default_value="true",
     ).lower()
     == "true"
     else False

--- a/app/core/resources/constants/service.py
+++ b/app/core/resources/constants/service.py
@@ -8,9 +8,29 @@ from app.core.resources.config_loader import read_config
 # SERVICE CONFIG
 _service_section_name: str = "service"
 NAME: str = read_config(section=_service_section_name, value="name")
-TIMEOUT: int = int(read_config(section=_service_section_name, value="timeout"))
+TIMEOUT: int = int(
+    read_config(section=_service_section_name, value="timeout_in_seconds")
+)
 IP: str = read_config(section=_service_section_name, value="ip")
 PORT: int = int(read_config(section=_service_section_name, value="port"))
+
+ENABLE_DOCUMENT_THUMBNAIL: bool = (
+    True
+    if read_config(
+        section=_service_section_name, value="enable_document_thumbnail"
+    ).lower()
+    == "true"
+    else False
+)
+
+ENABLE_DOCUMENT_PREVIEW = (
+    True
+    if read_config(
+        section=_service_section_name, value="enable_document_preview"
+    ).lower()
+    == "true"
+    else False
+)
 
 DESCRIPTION = """
 Preview service. 🚀 \n

--- a/app/core/resources/constants/service.py
+++ b/app/core/resources/constants/service.py
@@ -17,7 +17,9 @@ PORT: int = int(read_config(section=_service_section_name, value="port"))
 ENABLE_DOCUMENT_THUMBNAIL: bool = (
     True
     if read_config(
-        section=_service_section_name, value="enable_document_thumbnail"
+        section=_service_section_name,
+        value="enable_document_thumbnail",
+        default_value="false",
     ).lower()
     == "true"
     else False
@@ -26,7 +28,9 @@ ENABLE_DOCUMENT_THUMBNAIL: bool = (
 ENABLE_DOCUMENT_PREVIEW = (
     True
     if read_config(
-        section=_service_section_name, value="enable_document_preview"
+        section=_service_section_name,
+        value="enable_document_preview",
+        default_value="false",
     ).lower()
     == "true"
     else False

--- a/app/core/resources/constants/service.py
+++ b/app/core/resources/constants/service.py
@@ -32,6 +32,8 @@ ENABLE_DOCUMENT_PREVIEW = (
     else False
 )
 
+ARE_DOCS_ENABLED: bool = ENABLE_DOCUMENT_PREVIEW or ENABLE_DOCUMENT_THUMBNAIL
+
 DESCRIPTION = """
 Preview service. 🚀 \n
 You can preview the following type of files:

--- a/app/core/resources/constants/settings.py
+++ b/app/core/resources/constants/settings.py
@@ -10,6 +10,10 @@ NUMBER_OF_WORKERS: int = int(read_config(section=_libre_section, value="workers"
 
 LIBRE_OFFICE_PATH: str = read_config(section=_libre_section, value="path")
 
+LIBRE_OFFICE_TIMEOUT: int = int(
+    read_config(section=_libre_section, value="timeout_in_seconds")
+)
+
 # LOG
 _log_section: str = "log"
 LOG_FORMAT: str = read_config(section=_log_section, value="format", raw=True)

--- a/app/core/resources/data_validator.py
+++ b/app/core/resources/data_validator.py
@@ -8,13 +8,13 @@ from typing import Optional
 from starlette import status
 from starlette.responses import Response
 
-from app.core.resources.constants import message
+from app.core.resources.constants import message, service
 
 
 def is_id_valid(file_id: str) -> bool:
     """
     Validate the id, compares it to the structure of UUID1 to UUID4
-
+    \f
     :param file_id: id to validate
     :return: True if there was no error parsing it
     """
@@ -124,3 +124,37 @@ def check_for_image_metadata_errors(
             content=message.HEIGHT_WIDTH_NOT_VALID_ERROR,
             status_code=status.HTTP_400_BAD_REQUEST,
         )
+
+
+def check_if_document_thumbnail_is_enabled():
+    """
+    Checks if the document thumbnail option is enabled
+    \f
+    :return: a Response with status code 400 and content with
+     detailed explanation if thumbnail is not enabled
+    """
+    return (
+        None
+        if service.ENABLE_DOCUMENT_THUMBNAIL
+        else Response(
+            content=message.DOCUMENT_THUMBNAIL_NOT_ENABLED_ERROR,
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+    )
+
+
+def check_if_document_preview_is_enabled():
+    """
+    Checks if the document preview option is enabled
+    \f
+    :return: a Response with status code 400 and content with
+     detailed explanation if preview is not enabled
+    """
+    return (
+        None
+        if service.ENABLE_DOCUMENT_PREVIEW
+        else Response(
+            content=message.DOCUMENT_PREVIEW_NOT_ENABLED_ERROR,
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+    )

--- a/app/core/resources/data_validator.py
+++ b/app/core/resources/data_validator.py
@@ -126,7 +126,7 @@ def check_for_image_metadata_errors(
         )
 
 
-def check_if_document_thumbnail_is_enabled():
+def check_if_document_thumbnail_is_enabled() -> Optional[Response]:
     """
     Checks if the document thumbnail option is enabled
     \f
@@ -143,7 +143,7 @@ def check_if_document_thumbnail_is_enabled():
     )
 
 
-def check_if_document_preview_is_enabled():
+def check_if_document_preview_is_enabled() -> Optional[Response]:
     """
     Checks if the document preview option is enabled
     \f

--- a/app/core/resources/libre_office_handler.py
+++ b/app/core/resources/libre_office_handler.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 from threading import Thread
 
+from app.core.resources.constants import service
 from app.core.resources.constants.settings import (
     LIBRE_OFFICE_PATH,
 )
@@ -43,6 +44,9 @@ def boot_libre_instance(interface: str = IP, log: logging = logger) -> bool:
     :param log: logger to use
     :return: True if the service booted up correctly
     """
+    if not service.ARE_DOCS_ENABLED:
+        return True
+
     global libre_instance
     global libre_port
     sleep = 12

--- a/app/core/resources/libre_office_handler.py
+++ b/app/core/resources/libre_office_handler.py
@@ -7,6 +7,7 @@ from app.core.resources.constants.settings import (
     LIBRE_OFFICE_PATH,
 )
 from app.core.resources.constants.service import IP
+from app.core.resources.constants.settings import LIBRE_OFFICE_TIMEOUT
 from unoserver.server import UnoServer
 from subprocess import Popen  # nosec
 import random
@@ -68,12 +69,12 @@ def boot_libre_instance(interface: str = IP, log: logging = logger) -> bool:
 
 
 def watchdog_threaded_function():
-    watchdog_sleep_time = 60
+    watchdog_sleep_time = 30
     while True:
         logger.debug(
             f"Checking LibreOffice status at ip: {IP} and port: {libre_port}.."
         )
-        if not is_libre_instance_up(watchdog_sleep_time):
+        if not is_libre_instance_up(LIBRE_OFFICE_TIMEOUT):
             logger.info(
                 f"LibreOffice is offline at ip: {IP} and port: {libre_port}"
                 f" with pid {libre_instance.pid}, restarting worker .."

--- a/app/core/routers/document.py
+++ b/app/core/routers/document.py
@@ -13,6 +13,8 @@ from app.core.resources.data_validator import (
     is_id_valid,
     check_for_image_metadata_errors,
     check_for_document_metadata_errors,
+    check_if_document_preview_is_enabled,
+    check_if_document_thumbnail_is_enabled,
 )
 from app.core.resources.schemas.enums.image_border_form_enum import ImageBorderShapeEnum
 from app.core.resources.schemas.enums.image_quality_enum import ImageQualityEnum
@@ -61,6 +63,13 @@ async def get_preview(
     :return: 400 if there were invalid parameters, otherwise
     the requested file converted accordingly to pdf.
     """
+
+    document_preview_service_errors: Optional[
+        Response
+    ] = check_if_document_preview_is_enabled()
+    if document_preview_service_errors:
+        return document_preview_service_errors
+
     validation_errors: Optional[Response] = check_for_document_metadata_errors(
         first_page=first_page,
         last_page=last_page,
@@ -101,6 +110,11 @@ async def post_preview(
     :return: 400 if there were invalid parameters, otherwise
     the requested file converted accordingly to pdf.
     """
+    document_preview_service_errors: Optional[
+        Response
+    ] = check_if_document_preview_is_enabled()
+    if document_preview_service_errors:
+        return document_preview_service_errors
 
     validation_errors: Optional[Response] = check_for_document_metadata_errors(
         first_page=first_page,
@@ -150,6 +164,13 @@ async def post_thumbnail(
     :return: 400 if there were invalid parameters, otherwise
     the requested image modified accordingly.
     """
+
+    document_thumbnail_service_errors: Optional[
+        Response
+    ] = check_if_document_thumbnail_is_enabled()
+    if document_thumbnail_service_errors:
+        return document_thumbnail_service_errors
+
     metadata_dict = {
         "quality": quality,
         "format": output_format,
@@ -219,12 +240,19 @@ async def get_thumbnail(
     the requested pdf modified accordingly.
     """
 
+    document_thumbnail_service_errors: Optional[
+        Response
+    ] = check_if_document_thumbnail_is_enabled()
+    if document_thumbnail_service_errors:
+        return document_thumbnail_service_errors
+
     metadata_dict = {
         "quality": quality,
         "format": output_format,
         "shape": shape,
         "crop_position": VerticalCropPositionEnum.TOP,
     }
+
     validation_errors: Optional[Response] = check_for_image_metadata_errors(
         area=area,
         metadata_dict=metadata_dict,

--- a/app/core/routers/health.py
+++ b/app/core/routers/health.py
@@ -33,10 +33,7 @@ async def health() -> dict:
     """
 
     req = f"{storage.FULL_ADDRESS}/{storage.HEALTH_CHECK_API}"
-    is_libre_enabled: bool = (
-        service.ENABLE_DOCUMENT_PREVIEW or service.ENABLE_DOCUMENT_THUMBNAIL
-    )
-    is_libre_up: bool = is_libre_instance_up() if is_libre_enabled else False
+    is_libre_up: bool = is_libre_instance_up() if service.ARE_DOCS_ENABLED else False
     try:
         response = requests.get(req, timeout=5)
         response.raise_for_status()
@@ -57,7 +54,7 @@ async def health() -> dict:
                 "name": "libreoffice",
                 "ready": is_libre_up,
                 "live": is_libre_up,
-                "type": "REQUIRED" if is_libre_enabled else "OPTIONAL",
+                "type": "REQUIRED" if service.ARE_DOCS_ENABLED else "OPTIONAL",
             },
         ],
     }
@@ -72,10 +69,7 @@ async def health_ready() -> Response:
     \f
     :return: returns 200 if service and libreoffice are running
     """
-    is_libre_enabled = (
-        service.ENABLE_DOCUMENT_THUMBNAIL or service.ENABLE_DOCUMENT_PREVIEW
-    )
-    if not is_libre_enabled or is_libre_instance_up():
+    if not service.ARE_DOCS_ENABLED or is_libre_instance_up():
         logger.debug("Health ready with status code 200")
         return Response(status_code=status.HTTP_200_OK)
     else:

--- a/app/core/services/document_manipulation/document_manipulation.py
+++ b/app/core/services/document_manipulation/document_manipulation.py
@@ -221,8 +221,8 @@ async def _convert_with_libre(
         logger.warning(f"LibreOffice is not responding.. error {time_error}")
         sys.exit(1)
     except Exception as e:
-        logger.debug(
-            f"File to convert was empty, libre conversion failed with error {e}"
+        logger.info(
+            f"File to convert was corrupted, libre conversion failed with error {e}"
         )
 
     return out_data

--- a/app/core/services/document_manipulation/document_manipulation.py
+++ b/app/core/services/document_manipulation/document_manipulation.py
@@ -13,7 +13,7 @@ from pdfrw.errors import PdfParseError
 from starlette.exceptions import HTTPException
 
 from app.core.resources import libre_office_handler
-from app.core.resources.constants import service
+from app.core.resources.constants import service, settings
 from app.core.resources.schemas.enums.image_quality_enum import ImageQualityEnum
 from app.core.services.image_manipulation import image_manipulation
 
@@ -215,7 +215,7 @@ async def _convert_with_libre(
             content,
             output_extension,
         )
-        out_data = io.BytesIO(future.result(timeout=service.TIMEOUT))
+        out_data = io.BytesIO(future.result(timeout=settings.LIBRE_OFFICE_TIMEOUT))
         out_data.seek(0)
     except TimeoutError as time_error:
         logger.warning(f"LibreOffice is not responding.. error {time_error}")

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -21,8 +21,8 @@ spec:
   providesApis:
     - carbonio-preview-ce-rest-api
   dependsOn:
-    - carbonio-storages-ce
-    - carbonio-storages-ce-java-sdk
+    - component: carbonio-storages-ce
+    - component: carbonio-storages-ce-java-sdk
 
 ---
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -4,9 +4,9 @@
 
 -r requirements.txt
 
-black~=22.3.0
-flake8~=4.0.1
+black~=22.10.0
+flake8~=6.0.0
 bandit~=1.7.4
-pre-commit~=2.19.0
+pre-commit~=2.20.0
 
-responses~=0.21.0
+responses~=0.22.0

--- a/package/config.ini
+++ b/package/config.ini
@@ -13,7 +13,7 @@ health_name = health
 pdf_name = pdf
 document_name = document
 
-# when this option is set to true it will enable the docs-core dependency
+# when one of these two options is set to true it will enable the docs-core dependency
 # for generation of document previews or thumbnail. This requires more resources and should
 # be kept disabled in a system with low resources. It should only be enabled when the
 # preview service has a node dedicated to himself!

--- a/package/config.ini
+++ b/package/config.ini
@@ -6,12 +6,19 @@
 name = preview
 ip = 127.78.0.6
 port = 10000
-timeout = 30
+timeout_in_seconds = 30
 
 image_name = image
 health_name = health
 pdf_name = pdf
 document_name = document
+
+# when this option is set to true it will enable the docs-core dependency
+# for generation of document previews or thumbnail. This requires more resources and should
+# be kept disabled in a system with low resources. It should only be enabled when the
+# preview service has a node dedicated to himself!
+enable_document_preview = true
+enable_document_thumbnail = false
 
 [log]
 format = "[%(asctime)s] %(levelname)s [%(name)s.%(funcName)s:%(lineno)d] %(message)s"
@@ -34,3 +41,4 @@ port = 20000
 path = /opt/zextras/docs/core/program/soffice.bin
 # Generally we recommend (2 x $num_cores) + 1 as the number of workers to start off with.
 workers = 2
+timeout_in_seconds = 15

--- a/package/messages.ini
+++ b/package/messages.ini
@@ -17,3 +17,5 @@ id_not_valid_error = Id is not in a valid format, UUID1 to UUID4 are supported.
 version_not_valid_error = Version is not valid, the accepted values are > 0.
 format_not_supported_error = Format not supported.
 file_not_valid_error = The input file should not be null.
+document_thumbnail_not_enabled_error = The document thumbnail function is not currently enabled!
+document_preview_not_enabled_error = The document preview function is not currently enabled!

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,18 +2,18 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-FastAPI~=0.85.1
+FastAPI~=0.88.0
 
-uvicorn~=0.17.0
+uvicorn~=0.20.0
 gunicorn~=20.1.0
 
-requests~=2.27.1
+requests~=2.28.1
 
-Pillow~=9.2.0
+Pillow~=9.3.0
 pdfrw~=0.4
-pypdfium2~=2.5.0
+pypdfium2~=3.10.0
 
 unoserver==1.2
-psutil==5.9.0
+psutil==5.9.4
 
 python-multipart


### PR DESCRIPTION
# Description

It was required to allow a sysadmin the possibility to disable the thumbnail or preview of document files via config. This request was born from the necessity to have a preview service that could work on machines with low resources and docs-core requires a lot of them.

## Type of change

Please delete options that are not relevant or put an 'x' on the desired options.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
# Checklist:

This checklist is used as a reminder to avoid half-baked code
- [x] The PR title follows the following structure:" type[optional scope]: PREV-XX - LONG DESCRIPTION "
- [ ] I have bumped both the PKGBUILD version and controller version, and they are the same.
- [x] I have correctly installed and enabled pre-commit
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] If I have introduced new dependencies I have added them to the pre-commit unittest additional_dependencies AND to the THIRDPARTIES file