### PR TITLE
fix: PREV-100 - Sanitize pattern MUST be of the same type of the buffer

### DIFF
--- a/app/core/services/document_manipulation/document_manipulation.py
+++ b/app/core/services/document_manipulation/document_manipulation.py
@@ -166,12 +166,13 @@ async def convert_pdf_to_image(
         raise HTTPException(status_code=400, detail="Invalid pdf file")
 
 
-def _get_sanitize_offset(buffer: io.BytesIO, pattern_to_find: str = "%PDF") -> int:
+def _get_sanitize_offset(buffer: io.BytesIO, pattern_to_find: bytes = b"%PDF") -> int:
     """
     Calculates how many bytes to skip to avoid extra headers, it continues until
     it finds the pattern requested
     \f
-    :param buffer: pdf to search inside
+    :param buffer: pdf to search inside, the pattern MUST be of
+    the same type of the buffer
     :param pattern_to_find: pattern to search for inside the pdf,
     every byte before the pattern will be summed up and returned
     :returns: number of bytes before the pattern to find

--- a/tests/core/services/document_manipulation/test_document_manipulation.py
+++ b/tests/core/services/document_manipulation/test_document_manipulation.py
@@ -98,7 +98,7 @@ class TestPdfManipulation(IsolatedAsyncioTestCase):
 def test_given_pdf_without_extra_headers_sanitize_offset_should_return_0(expect):
     # Given
     buff_argument = io.BytesIO()
-    pdf_content: List[str] = ["%PDF-1.5", "pdf_content1", "pdf_content2"]
+    pdf_content: List[bytes] = [b"%PDF-1.5", b"pdf_content1", b"pdf_content2"]
     expect(document_manipulation, times=1)._read_buffer_line_by_line(
         buff_argument
     ).thenReturn(pdf_content)
@@ -115,7 +115,7 @@ def test_given_pdf_with_one_extra_headers_sanitize_offset_should_return_len_firs
 ):
     # Given
     buff_argument = io.BytesIO()
-    pdf_content: List[str] = ["extra-header" "%PDF-1.5", "pdf_content1"]
+    pdf_content: List[bytes] = [b"extra-header" b"%PDF-1.5", b"pdf_content1"]
     expect(document_manipulation, times=1)._read_buffer_line_by_line(
         buff_argument
     ).thenReturn(pdf_content)
@@ -130,15 +130,15 @@ def test_given_pdf_with_one_extra_headers_sanitize_offset_should_return_len_firs
 @pytest.mark.parametrize(
     "in_out_tuple",
     [
-        (["x%PDF-1.5"], 1),
-        (["xxxx%PDF-1.5"], 4),
-        (["xxxxxxxxxxx%PDF-1.5"], 11),
-        (["x%PDF-1.5", "pdf-content"], 1),
-        (["pdf-content", "x%PDF-1.5"], 12),
-        (["xxxx%PDF-1.5", "pdf-content"], 4),
-        (["pdf-content", "xxxx%PDF-1.5"], 15),
-        (["xxxxxxxxxxx%PDF-1.5", "pdf-content"], 11),
-        (["pdf-content", "xxxxxxxxxxx%PDF-1.5"], 22),
+        ([b"x%PDF-1.5"], 1),
+        ([b"xxxx%PDF-1.5"], 4),
+        ([b"xxxxxxxxxxx%PDF-1.5"], 11),
+        ([b"x%PDF-1.5", b"pdf-content"], 1),
+        ([b"pdf-content", b"x%PDF-1.5"], 12),
+        ([b"xxxx%PDF-1.5", b"pdf-content"], 4),
+        ([b"pdf-content", b"xxxx%PDF-1.5"], 15),
+        ([b"xxxxxxxxxxx%PDF-1.5", b"pdf-content"], 11),
+        ([b"pdf-content", b"xxxxxxxxxxx%PDF-1.5"], 22),
     ],
 )
 def test_given_pdf_with_extra_headers_sanitize_offset_should_return_correct_size(
@@ -162,7 +162,7 @@ def test_given_pdf_without_correct_header_and_multiple_lines_offset_should_retur
 ):
     # Given
     buff_argument = io.BytesIO()
-    str_to_search = ["zextras", "-", "test-rakuja"]
+    str_to_search = [b"zextras", b"-", b"test-rakuja"]
     expect(document_manipulation, times=1)._read_buffer_line_by_line(
         buff_argument
     ).thenReturn(str_to_search)
@@ -179,10 +179,10 @@ def test_given_pdf_without_correct_header_and_single_line_offset_should_return_s
 ):
     # Given
     buff_argument = io.BytesIO()
-    str_to_search = "zextras-test-rakuja"
+    str_to_search = b"zextras-test-rakuja"
     expect(document_manipulation, times=1)._read_buffer_line_by_line(
         buff_argument
-    ).thenReturn(str_to_search)
+    ).thenReturn([str_to_search])
 
     # When
     result = document_manipulation._get_sanitize_offset(buff_argument)


### PR DESCRIPTION
# Description

In the unit tests we used strings to mock read line by line on buffer. This meant that startswith was done on strings and expected a pattern of type string. In truth the service uses bytes buffers, this means that it expected a pattern made of bytes and we passed a string, causing a runtime exception

## Type of change

Please delete options that are not relevant or put an 'x' on the desired options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
# Checklist:

This checklist is used as a reminder to avoid half-baked code
- [x] The PR title follows the following structure:" type[optional scope]: PREV-XX - LONG DESCRIPTION "
- [x] I have bumped both the PKGBUILD version and controller version, and they are the same.
- [x] I have correctly installed and enabled pre-commit
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] If I have introduced new dependencies I have added them to the pre-commit unittest additional_dependencies AND to the THIRDPARTIES file