### PR TITLE
PREV-81 - Handle multiple worker logging to a single file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         args: []
 
 -   repo: https://github.com/python/black.git
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
       - id: black
 

--- a/app/controller.py
+++ b/app/controller.py
@@ -14,7 +14,7 @@ from app.core.routers import image, health, pdf, document
 
 app = FastAPI(
     title=service.NAME,
-    version="0.2.14",
+    version="0.2.15",
     description=service.DESCRIPTION,
 )
 

--- a/app/gunicorn.conf.py
+++ b/app/gunicorn.conf.py
@@ -157,7 +157,6 @@ capture_output = False
 # Set up a queue to communicate with the handlers
 log_queue = multiprocessing.Queue()
 
-# Create a listener and add it to the root logger
 queue_timed_rotating_handler = TimedRotatingFileHandler(
     filename=log_path,
     when="d",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -4,11 +4,11 @@
 
 -r requirements.txt
 
-black~=22.12.0
+black~=23.1.0
 flake8~=6.0.0
 Flake8-pyproject~=1.2.2
 bandit~=1.7.4
-pre-commit~=3.0.2
+pre-commit~=3.1.0
 
 responses~=0.22.0
 

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -40,11 +40,12 @@ makedepends:apt=(
 )
 
 provides:yum=(
-  "libjpeg-b1f3a3b7.so.62.3.0(LIBJPEG_6.2)(64bit)"
-  "liblzma-816f5b19.so.5.2.7(XZ_5.0)(64bit)"
-  "libpng16-a57c74e2.so.16.38.0(PNG16_0)(64bit)"
+  "libjpeg-2c0fa17f.so.62.3.0(LIBJPEG_6.2)(64bit)"
+  "liblzma-85b6360a.so.5.4.0(XZ_5.0)(64bit)"
+  "libpng16-021811b1.so.16.39.0(PNG16_0)(64bit)"
   "libz-dd453c56.so.1.2.11(ZLIB_1.2.3.4)(64bit)"
   "libz-dd453c56.so.1.2.11(ZLIB_1.2.9)(64bit)"
+  "libtiff-ac0c3d92.so.6.0.0(LIBTIFF_4.0)(64bit)"
   "/bin/python3.8"
 )
 

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -3,7 +3,7 @@ targets=(
    "ubuntu"
 )
 pkgname="carbonio-preview-ce"
-pkgver="0.2.14"
+pkgver="0.2.15"
 pkgrel="1"
 pkgdesc="Carbonio Preview"
 pkgdesclong=(

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,16 +2,16 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-FastAPI~=0.89.1
+FastAPI~=0.92.0
 
 uvicorn~=0.20.0
 gunicorn~=20.1.0
 
 requests~=2.28.2
 
-Pillow~=9.3.0
+Pillow~=9.4.0
 pdfrw~=0.4
-pypdfium2~=3.20.0
+pypdfium2~=3.21.1
 
 unoserver==1.2
 psutil==5.9.4

--- a/rest-api.yaml
+++ b/rest-api.yaml
@@ -6,7 +6,7 @@ openapi: 3.0.2
 info:
   title: preview
   description: "\nPreview service. \U0001F680 \n\nYou can preview the following type of files:\n\n* **images(png/jpeg)**\n* **pdf**\n* **documents (xls, xlsx, ods, ppt, pptx, odp, doc, docx, odt)**\n\nYou will be able to:\n\n* **Preview images**.\n* **Generate smart thumbnails**.\n\nThe main difference between thumbnail and preview\n functionality is that preview tends to be more faithful\nwhile thumbnail tends to elaborate on it, cropping\n it by default and rounding the image if asked.\nPreview should always output the file in its original format,\n while thumbnail will convert it to an image.\nThere is no difference in quality between the two,\n the difference in quality can be achieved only\nby asking for a jpeg format and changing the quality parameter.\n"
-  version: 0.2.14
+  version: 0.2.15
 paths:
   '/preview/image/{id}/{version}/{area}/thumbnail/':
     get:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 setup(
     name="carbonio-preview-ce",
     packages=find_packages(),
-    version="0.2.14",
+    version="0.2.15",
     entry_points={"console_scripts": ["controller = controller:main"]},
     description="Carbonio Preview.",
     long_description=open("README.md").read(),


### PR DESCRIPTION
# Description

Introduction of a queue in which the various worker will send the information, a separate thread will then handle the queue and write to file, avoiding concurrency problems.

Also updated FastApi and Pillow. They had urgent security updates.

## Type of change

Please delete options that are not relevant or put an 'x' on the desired options.

- [x] Bug fix (non-breaking change which fixes an issue)
# Checklist:

This checklist is used as a reminder to avoid half-baked code
- [x] The PR title follows the following structure:" type[optional scope]: PREV-XX - LONG DESCRIPTION "
- [x] I have bumped both the PKGBUILD version and controller version, and they are the same.
- [x] I have correctly installed and enabled pre-commit
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] If I have introduced new dependencies I have added them to the pre-commit unittest additional_dependencies AND to the THIRDPARTIES file