### PR TITLE
chore: bump dependencies version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,14 +4,14 @@
 
 repos:
 -   repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v2.1.1
+    rev: v2.2.0
     hooks:
     -   id: conventional-pre-commit
         stages: [commit-msg]
         args: []
 
 -   repo: https://github.com/python/black.git
-    rev: 23.1.0
+    rev: 23.3.0
     hooks:
       - id: black
 
@@ -31,7 +31,7 @@ repos:
       additional_dependencies: [Flake8-pyproject]
 
 -   repo: https://github.com/fsfe/reuse-tool
-    rev: v1.1.0
+    rev: v1.1.2
     hooks:
         - id: reuse
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -4,13 +4,13 @@
 
 -r requirements.txt
 
-black~=23.1.0
+black~=23.3.0
 flake8~=6.0.0
 Flake8-pyproject~=1.2.2
 bandit~=1.7.4
-pre-commit~=3.1.0
+pre-commit~=3.2.2
 
-responses~=0.22.0
+responses~=0.23.1
 
-pytest~=7.2.1
+pytest~=7.3.1
 pytest-mockito~=0.0.4

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -39,8 +39,8 @@ makedepends:apt=(
 )
 
 provides:yum=(
-  "libjpeg-2c0fa17f.so.62.3.0(LIBJPEG_6.2)(64bit)"
-  "liblzma-85b6360a.so.5.4.0(XZ_5.0)(64bit)"
+  "libjpeg-2caf4b68.so.62.3.0(LIBJPEG_6.2)(64bit)"
+  "liblzma-72f7b2a5.so.5.4.2(XZ_5.0)(64bit)"
   "libpng16-021811b1.so.16.39.0(PNG16_0)(64bit)"
   "libz-dd453c56.so.1.2.11(ZLIB_1.2.3.4)(64bit)"
   "libz-dd453c56.so.1.2.11(ZLIB_1.2.9)(64bit)"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,17 +2,17 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-FastAPI~=0.92.0
+FastAPI~=0.95.1
 
-uvicorn~=0.20.0
+uvicorn~=0.21.1
 gunicorn~=20.1.0
 
-requests~=2.28.2
+requests~=2.29.0
 
-Pillow~=9.4.0
+Pillow~=9.5.0
 pdfrw~=0.4
-pypdfium2~=3.21.1
+pypdfium2~=4.8.0
 
-psutil==5.9.4
+psutil==5.9.5
 
 python-multipart


### PR DESCRIPTION
# Description

Bump dependencies used. I checked from the CHANGELOG of each library and it should not have any breaking changes affecting the preview service

## Type of change

Please delete options that are not relevant or put an 'x' on the desired options.

- [x] This change requires a documentation update
# Checklist:

This checklist is used as a reminder to avoid half-baked code
- [x] The PR title follows the following structure:" type[optional scope]: PREV-XX - LONG DESCRIPTION "
- [x] I have bumped both the PKGBUILD version and controller version, and they are the same.
- [x] I have correctly installed and enabled pre-commit
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] If I have introduced new dependencies I have added them to the pre-commit unittest additional_dependencies AND to the THIRDPARTIES file