### PR TITLE
chore(release): 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,136 @@
+<!--
+SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
+# Changelog
+
+## v0.3.0 (2023-04-27)
+
+#### New Features
+
+* Introduce docs editor ([#30](https://github.com/Zextras/carbonio-preview-ce/issues/30))
+#### Others
+
+* upgrade dependencies ([#32](https://github.com/Zextras/carbonio-preview-ce/issues/32))
+* (infra): update intentions.json aligning it to new chats naming ([#31](https://github.com/Zextras/carbonio-preview-ce/issues/31))
+
+Full set of changes: [`v0.2.15...v0.3.0`](https://github.com/Zextras/carbonio-preview-ce/compare/v0.2.15...v0.3.0)
+
+## v0.2.15 (2023-02-28)
+
+
+Full set of changes: [`v0.2.14...v0.2.15`](https://github.com/Zextras/carbonio-preview-ce/compare/v0.2.14...v0.2.15)
+
+## v0.2.14 (2023-02-01)
+
+#### Fixes
+
+* PREV-100 - Sanitize pattern MUST be of the same type of the buffer ([#28](https://github.com/Zextras/carbonio-preview-ce/issues/28))
+* PREV-100 : Remove extra headers at the beginning of pdfs ([#27](https://github.com/Zextras/carbonio-preview-ce/issues/27))
+* PREV-97 - Update RHEL provided dependencies in PKGBUILD ([#26](https://github.com/Zextras/carbonio-preview-ce/issues/26))
+
+Full set of changes: [`v0.2.13...v0.2.14`](https://github.com/Zextras/carbonio-preview-ce/compare/v0.2.13...v0.2.14)
+
+## v0.2.13 (2022-12-01)
+
+#### New Features
+
+* PREV-96 - Disable Docs-Core via config ([#24](https://github.com/Zextras/carbonio-preview-ce/issues/24))
+#### Fixes
+
+* PREV-95 - Kill Docs-Core process ([#23](https://github.com/Zextras/carbonio-preview-ce/issues/23))
+#### Others
+
+* bump version, fix catalog-info.yaml, add fastapi to THIRDPARTIES ([#25](https://github.com/Zextras/carbonio-preview-ce/issues/25))
+* PREV-93 - Add backstage catalog-info.yaml ([#21](https://github.com/Zextras/carbonio-preview-ce/issues/21))
+
+Full set of changes: [`v0.2.12...v0.2.13`](https://github.com/Zextras/carbonio-preview-ce/compare/v0.2.12...v0.2.13)
+
+## v0.2.12 (2022-10-26)
+
+#### Others
+
+* bump version ([#22](https://github.com/Zextras/carbonio-preview-ce/issues/22))
+* usage of internal docs resources ([#20](https://github.com/Zextras/carbonio-preview-ce/issues/20))
+
+Full set of changes: [`v0.2.11...v0.2.12`](https://github.com/Zextras/carbonio-preview-ce/compare/v0.2.11...v0.2.12)
+
+## v0.2.11 (2022-09-01)
+
+#### Fixes
+
+* PREV-63 - Rotate image with EXIF metadata ([#19](https://github.com/Zextras/carbonio-preview-ce/issues/19))
+* PREV-85 - Add libre office watchdog ([#18](https://github.com/Zextras/carbonio-preview-ce/issues/18))
+#### Others
+
+* IN-497 - Add missing rhel8 provides ([#17](https://github.com/Zextras/carbonio-preview-ce/issues/17))
+
+Full set of changes: [`v0.2.10...v0.2.11`](https://github.com/Zextras/carbonio-preview-ce/compare/v0.2.10...v0.2.11)
+
+## v0.2.10 (2022-07-20)
+
+#### New Features
+
+* add python build facilities aimed at packaging simplification ([#12](https://github.com/Zextras/carbonio-preview-ce/issues/12))
+#### Fixes
+
+* PREV-72 - Thumbnail generation goes in timeout ([#13](https://github.com/Zextras/carbonio-preview-ce/issues/13))
+* PREV-80 - add missing group at user creation ([#15](https://github.com/Zextras/carbonio-preview-ce/issues/15))
+* PREV-71 - Thumbnail of encrypted PDFs are returned blank ([#11](https://github.com/Zextras/carbonio-preview-ce/issues/11))
+#### Others
+
+* bump version ([#16](https://github.com/Zextras/carbonio-preview-ce/issues/16))
+
+Full set of changes: [`v0.2.9...v0.2.10`](https://github.com/Zextras/carbonio-preview-ce/compare/v0.2.9...v0.2.10)
+
+## v0.2.9 (2022-06-09)
+
+#### Fixes
+
+* PREV-70 - Rotate logs daily ([#10](https://github.com/Zextras/carbonio-preview-ce/issues/10))
+* PREV-68 - LibreOffice is spiking Memory Usage ([#9](https://github.com/Zextras/carbonio-preview-ce/issues/9))
+
+Full set of changes: [`v0.2.8...v0.2.9`](https://github.com/Zextras/carbonio-preview-ce/compare/v0.2.8...v0.2.9)
+
+## v0.2.8 (2022-05-16)
+
+#### Fixes
+
+* PREV-51 - Fix 500 when input file empty ([#8](https://github.com/Zextras/carbonio-preview-ce/issues/8))
+
+Full set of changes: [`v0.2.7...v0.2.8`](https://github.com/Zextras/carbonio-preview-ce/compare/v0.2.7...v0.2.8)
+
+## v0.2.7 (2022-05-09)
+
+#### New Features
+
+* PREV-12 - configure logging ([#4](https://github.com/Zextras/carbonio-preview-ce/issues/4))
+#### Fixes
+
+* PREV-55 - Change libreoffice-calc package ([#6](https://github.com/Zextras/carbonio-preview-ce/issues/6))
+* PREV-54 - restart LibreOffice instance when worker restarts ([#5](https://github.com/Zextras/carbonio-preview-ce/issues/5))
+#### Others
+
+* update requirements ([#7](https://github.com/Zextras/carbonio-preview-ce/issues/7))
+
+Full set of changes: [`v0.2.4...v0.2.7`](https://github.com/Zextras/carbonio-preview-ce/compare/v0.2.4...v0.2.7)
+
+## v0.2.4 (2022-04-08)
+
+#### New Features
+
+* PREV-48 - document's preview and thumbnail ([#3](https://github.com/Zextras/carbonio-preview-ce/issues/3))
+* PREV-19 - crop thumbnail from the top for documents ([#2](https://github.com/Zextras/carbonio-preview-ce/issues/2))
+
+Full set of changes: [`v0.2.2...v0.2.4`](https://github.com/Zextras/carbonio-preview-ce/compare/v0.2.2...v0.2.4)
+
+## v0.2.2 (2022-03-23)
+
+#### New Features
+
+* carbonio release
+#### Fixes
+
+* PREV-46 / PREV-47 - fix requirements

--- a/app/controller.py
+++ b/app/controller.py
@@ -12,7 +12,7 @@ from app.core.routers import image, health, pdf, document
 
 app = FastAPI(
     title=service.NAME,
-    version="0.2.15-3",
+    version="0.3.0-1",
     description=service.DESCRIPTION,
 )
 

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -3,8 +3,8 @@ targets=(
    "ubuntu"
 )
 pkgname="carbonio-preview-ce"
-pkgver="0.2.15"
-pkgrel="3"
+pkgver="0.3.0"
+pkgrel="1"
 pkgdesc="Carbonio Preview"
 pkgdesclong=(
   "Carbonio Preview"

--- a/rest-api.yaml
+++ b/rest-api.yaml
@@ -6,7 +6,7 @@ openapi: 3.0.2
 info:
   title: preview
   description: "\nPreview service. \U0001F680 \n\nYou can preview the following type of files:\n\n* **images(png/jpeg)**\n* **pdf**\n* **documents (xls, xlsx, ods, ppt, pptx, odp, doc, docx, odt)**\n\nYou will be able to:\n\n* **Preview images**.\n* **Generate smart thumbnails**.\n\nThe main difference between thumbnail and preview\n functionality is that preview tends to be more faithful\nwhile thumbnail tends to elaborate on it, cropping\n it by default and rounding the image if asked.\nPreview should always output the file in its original format,\n while thumbnail will convert it to an image.\nThere is no difference in quality between the two,\n the difference in quality can be achieved only\nby asking for a jpeg format and changing the quality parameter.\n"
-  version: 0.2.15-3
+  version: 0.3.0-1
 paths:
   '/preview/image/{id}/{version}/{area}/thumbnail/':
     get:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 setup(
     name="carbonio-preview-ce",
     packages=find_packages(),
-    version="0.2.15-3",
+    version="0.3.0-1",
     entry_points={"console_scripts": ["controller = controller:main"]},
     description="Carbonio Preview.",
     long_description=open("README.md").read(),


### PR DESCRIPTION
# Description

Release v0.3.0. Main change is that docs dependency is no more inside the preview service, instead it uses REST API to communicate with docs-editor for document conversion. This speeds up carbonio-preview bootup and also relieves the service of docs-core handling logic. Many docs that could not be converted now are handled correctly.

## Type of change

Please delete options that are not relevant or put an 'x' on the desired options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
# Checklist:

This checklist is used as a reminder to avoid half-baked code
- [x] The PR title follows the following structure:" type[optional scope]: PREV-XX - LONG DESCRIPTION "
- [x] I have bumped both the PKGBUILD version and controller version, and they are the same.
- [x] I have correctly installed and enabled pre-commit
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] If I have introduced new dependencies I have added them to the pre-commit unittest additional_dependencies AND to the THIRDPARTIES file