### PR TITLE
fix: PREV-110 - Swap deprecated render_topil 

### DIFF
--- a/app/controller.py
+++ b/app/controller.py
@@ -12,7 +12,7 @@ from app.core.routers import image, health, pdf, document
 
 app = FastAPI(
     title=service.NAME,
-    version="0.3.0-1",
+    version="0.3.0-2",
     description=service.DESCRIPTION,
 )
 

--- a/app/core/services/document_manipulation/document_manipulation.py
+++ b/app/core/services/document_manipulation/document_manipulation.py
@@ -150,7 +150,7 @@ async def convert_pdf_to_image(
     try:
         pdf = pypdfium2.PdfDocument(content)
         page = pdf.get_page(page_number)
-        pil_image = page.render_topil()
+        pil_image = page.render().to_pil()
         return image_manipulation.save_image_to_buffer(
             pil_image,
             output_extension,

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -4,7 +4,7 @@ targets=(
 )
 pkgname="carbonio-preview-ce"
 pkgver="0.3.0"
-pkgrel="1"
+pkgrel="2"
 pkgdesc="Carbonio Preview"
 pkgdesclong=(
   "Carbonio Preview"

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ requests~=2.29.0
 
 Pillow~=9.5.0
 pdfrw~=0.4
-pypdfium2~=4.8.0
+pypdfium2~=4.9.0
 
 psutil==5.9.5
 

--- a/rest-api.yaml
+++ b/rest-api.yaml
@@ -6,7 +6,7 @@ openapi: 3.0.2
 info:
   title: preview
   description: "\nPreview service. \U0001F680 \n\nYou can preview the following type of files:\n\n* **images(png/jpeg)**\n* **pdf**\n* **documents (xls, xlsx, ods, ppt, pptx, odp, doc, docx, odt)**\n\nYou will be able to:\n\n* **Preview images**.\n* **Generate smart thumbnails**.\n\nThe main difference between thumbnail and preview\n functionality is that preview tends to be more faithful\nwhile thumbnail tends to elaborate on it, cropping\n it by default and rounding the image if asked.\nPreview should always output the file in its original format,\n while thumbnail will convert it to an image.\nThere is no difference in quality between the two,\n the difference in quality can be achieved only\nby asking for a jpeg format and changing the quality parameter.\n"
-  version: 0.3.0-1
+  version: 0.3.0-2
 paths:
   '/preview/image/{id}/{version}/{area}/thumbnail/':
     get:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 setup(
     name="carbonio-preview-ce",
     packages=find_packages(),
-    version="0.3.0-1",
+    version="0.3.0-2",
     entry_points={"console_scripts": ["controller = controller:main"]},
     description="Carbonio Preview.",
     long_description=open("README.md").read(),


### PR DESCRIPTION
# Description

Pypdfium in the 4.x.x release deprecated the to_pil method in favour of render().to_pil()
commit: https://github.com/pypdfium2-team/pypdfium2/commit/2a6e8b7935adc45d67d2c8137d483ec774b044e2#diff-3d8268d1bacb872d3153db0a3ded75b35dc9b6c8db8432f628d09488494f5a02
## Type of change

Please delete options that are not relevant or put an 'x' on the desired options.

- [x] Bug fix (non-breaking change which fixes an issue)
# Checklist:

This checklist is used as a reminder to avoid half-baked code
- [x] The PR title follows the following structure:" type[optional scope]: PREV-XX - LONG DESCRIPTION "
- [x] I have bumped both the PKGBUILD version and controller version, and they are the same.
- [x] I have correctly installed and enabled pre-commit
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] If I have introduced new dependencies I have added them to the pre-commit unittest additional_dependencies AND to the THIRDPARTIES file