### PR TITLE
chore(release): 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,22 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # Changelog
 
+## v0.3.2 (2023-05-25)
+
+#### Fixes
+
+* Allow versions greater or equals than 0 ([#36](https://github.com/Zextras/carbonio-preview-ce/issues/36))
+
+Full set of changes: [`v0.3.1...v0.3.2`](https://github.com/Zextras/carbonio-preview-ce/compare/v0.3.1...v0.3.2)
+
 ## v0.3.1 (2023-05-08)
 
 #### Fixes
 
 * Swap deprecated render_topil  ([#34](https://github.com/Zextras/carbonio-preview-ce/issues/34))
+#### Others
+
+* (release): 0.3.1 ([#35](https://github.com/Zextras/carbonio-preview-ce/issues/35))
 
 Full set of changes: [`v0.3.0...v0.3.1`](https://github.com/Zextras/carbonio-preview-ce/compare/v0.3.0...v0.3.1)
 

--- a/app/controller.py
+++ b/app/controller.py
@@ -12,7 +12,7 @@ from app.core.routers import image, health, pdf, document
 
 app = FastAPI(
     title=service.NAME,
-    version="0.3.1-2",
+    version="0.3.2-1",
     description=service.DESCRIPTION,
 )
 

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -3,8 +3,8 @@ targets=(
    "ubuntu"
 )
 pkgname="carbonio-preview-ce"
-pkgver="0.3.1"
-pkgrel="2"
+pkgver="0.3.2"
+pkgrel="1"
 pkgdesc="Carbonio Preview"
 pkgdesclong=(
   "Carbonio Preview"

--- a/rest-api.yaml
+++ b/rest-api.yaml
@@ -6,7 +6,7 @@ openapi: 3.0.2
 info:
   title: preview
   description: "\nPreview service. \U0001F680 \n\nYou can preview the following type of files:\n\n* **images(png/jpeg)**\n* **pdf**\n* **documents (xls, xlsx, ods, ppt, pptx, odp, doc, docx, odt)**\n\nYou will be able to:\n\n* **Preview images**.\n* **Generate smart thumbnails**.\n\nThe main difference between thumbnail and preview\n functionality is that preview tends to be more faithful\nwhile thumbnail tends to elaborate on it, cropping\n it by default and rounding the image if asked.\nPreview should always output the file in its original format,\n while thumbnail will convert it to an image.\nThere is no difference in quality between the two,\n the difference in quality can be achieved only\nby asking for a jpeg format and changing the quality parameter.\n"
-  version: 0.3.1-2
+  version: 0.3.2-1
 paths:
   '/preview/image/{id}/{version}/{area}/thumbnail/':
     get:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 setup(
     name="carbonio-preview-ce",
     packages=find_packages(),
-    version="0.3.1-2",
+    version="0.3.2-1",
     entry_points={"console_scripts": ["controller = controller:main"]},
     description="Carbonio Preview.",
     long_description=open("README.md").read(),


### PR DESCRIPTION
# Description

The 0.3.2 release allows version with value = 0 to be parsed. This is done so that chats client can request previews. Also, every controller (router) has been refactored and uses pydantic for automatic field validation

## Type of change

Please delete options that are not relevant or put an 'x' on the desired options.

- [x] New feature (non-breaking change which adds functionality)
# Checklist:

This checklist is used as a reminder to avoid half-baked code
- [x] The PR title follows the following structure:" type[optional scope]: PREV-XX - LONG DESCRIPTION "
- [x] I have bumped both the PKGBUILD version and controller version, and they are the same.
- [x] I have correctly installed and enabled pre-commit
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] If I have introduced new dependencies I have added them to the pre-commit unittest additional_dependencies AND to the THIRDPARTIES file