### PR TITLE
fix: PREV-113 - Return image type enum value and not name

### DIFF
--- a/app/core/services/image_service.py
+++ b/app/core/services/image_service.py
@@ -119,7 +119,7 @@ async def _process_response_data(
         if response_error
         else Response(
             content=func(img_metadata=img_metadata, content=response_data.raw).read(),
-            media_type=f"image/{img_metadata.format}",
+            media_type=f"image/{img_metadata.format.value}",
         )
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ FastAPI~=0.95.2
 uvicorn~=0.22.0
 gunicorn~=20.1.0
 
-requests~=2.30.0
+requests~=2.31.0
 
 Pillow~=9.5.0
 pdfrw~=0.4


### PR DESCRIPTION
# Description

Image thumbnail returns for example "image/ImageType.JPEG" and not "image/jpeg" as the myme-type. Now this fixes the issue. Also update request library, had high security problems

## Type of change

Please delete options that are not relevant or put an 'x' on the desired options.

- [x] Bug fix (non-breaking change which fixes an issue)
# Checklist:

This checklist is used as a reminder to avoid half-baked code
- [x] The PR title follows the following structure:" type[optional scope]: PREV-XX - LONG DESCRIPTION "
- [x] I have bumped both the PKGBUILD version and controller version, and they are the same.
- [x] I have correctly installed and enabled pre-commit
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] If I have introduced new dependencies I have added them to the pre-commit unittest additional_dependencies AND to the THIRDPARTIES file