### PR TITLE
fix: PREV-112 - Allow preview of new PDF versions

### DIFF
--- a/THIRDPARTIES
+++ b/THIRDPARTIES
@@ -267,23 +267,6 @@ flake8
 2011-2013, Copyright Tarek Ziade <tarek@ziade.org>,
 2012-2016, Copyright Ian Cordasco <graffatcolmingov@gmail.com>;
 pre-commit, 2014, Copyright pre-commit dev team: Anthony Sottile, Ken Struys;
-pdfrw
-2006-2017, Copyright Patrick Maupin,
-2010, Copyright Attila Tajti,
-2012, Copyright Nerijus Mika,
-2015, Copyright Bastien Gandouet,
-2015, Copyright Tzerjen Wei,
-2015, Copyright Jorj X. McKie,
-2015, Copyright Nicholas Devenish,
-2015-2016, Copyright Jonatan Dellagostin,
-2016-2017, Copyright Thomas Kluyver,
-2016, Copyright James Laird-Wah,
-2016, Copyright Marcus Brinkmann,
-2016, Copyright Edward Betts,
-2016, Copyright Patrick Mazulo,
-2017, Copyright Haochen Wu,
-2017, Copyright Jon Lund Steffensen,
-2017, Copyright Henddher Pedroza;
 
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:

--- a/app/controller.py
+++ b/app/controller.py
@@ -12,7 +12,7 @@ from app.core.routers import image, health, pdf, document
 
 app = FastAPI(
     title=service.NAME,
-    version="0.3.3-1",
+    version="0.3.3-2",
     description=service.DESCRIPTION,
 )
 

--- a/app/core/resources/schemas/enums/image_type_enum.py
+++ b/app/core/resources/schemas/enums/image_type_enum.py
@@ -1,5 +1,4 @@
 # SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com
-# SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/app/core/services/document_manipulation/document_manipulation.py
+++ b/app/core/services/document_manipulation/document_manipulation.py
@@ -42,16 +42,16 @@ def split_pdf(
     return _write_pdf_to_buffer(pdf, start_page, end_page)
 
 
-def _parse_if_valid_pdf(raw_content: io.BytesIO) -> Optional[PdfDocument]:
+def _parse_if_valid_pdf(content: io.BytesIO) -> Optional[PdfDocument]:
     """
-    Parses the given bytes into PdfReader, if the file is not valid returns None
+    Parses the given buffer of bytes into PdfReader, if the file is not valid returns None
     \f
-    :param raw_content: file to load into a PdfDocument object
+    :param content: file to load into a PdfDocument object
     :return: PdfReader object containing the pdf or Empty if not valid
     """
     pdf = None
     try:
-        pdf = PdfDocument(raw_content)
+        pdf = PdfDocument(content)
     except PdfiumError as e:  # not a valid pdf
         logger.warning(
             f"Not a valid pdf file, replacing it with an empty one. Error: {e}"
@@ -64,9 +64,9 @@ def _write_pdf_to_buffer(
     pdf: Optional[PdfDocument] = None, start_page: int = 0, end_page: int = 1
 ) -> io.BytesIO:
     """
-    Writes file to PDF, if pdf is empty writes an empty pdf file
+    Writes PDF to io.BytesIO buffer, if PDF is empty writes an empty pdf file
     \f
-    :param pdf: list of PdfReader pages containing the content to write
+    :param pdf: PdfDocument containing the content to write
     :param start_page: first page to write
     :param end_page: last page to write
     :return: io.BytesIO object with pdf content written in it

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -4,7 +4,7 @@ targets=(
 )
 pkgname="carbonio-preview-ce"
 pkgver="0.3.3"
-pkgrel="1"
+pkgrel="2"
 pkgdesc="Carbonio Preview"
 pkgdesclong=(
   "Carbonio Preview"

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ requests~=2.31.0
 
 Pillow~=9.5.0
 pdfrw~=0.4
-pypdfium2~=4.11.0
+pypdfium2~=4.12.0
 
 psutil==5.9.5
 

--- a/rest-api.yaml
+++ b/rest-api.yaml
@@ -6,7 +6,7 @@ openapi: 3.0.2
 info:
   title: preview
   description: "\nPreview service. \U0001F680 \n\nYou can preview the following type of files:\n\n* **images(png/jpeg)**\n* **pdf**\n* **documents (xls, xlsx, ods, ppt, pptx, odp, doc, docx, odt)**\n\nYou will be able to:\n\n* **Preview images**.\n* **Generate smart thumbnails**.\n\nThe main difference between thumbnail and preview\n functionality is that preview tends to be more faithful\nwhile thumbnail tends to elaborate on it, cropping\n it by default and rounding the image if asked.\nPreview should always output the file in its original format,\n while thumbnail will convert it to an image.\nThere is no difference in quality between the two,\n the difference in quality can be achieved only\nby asking for a jpeg format and changing the quality parameter.\n"
-  version: 0.3.3-1
+  version: 0.3.3-2
 paths:
   '/preview/image/{id}/{version}/{area}/thumbnail/':
     get:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 setup(
     name="carbonio-preview-ce",
     packages=find_packages(),
-    version="0.3.3-1",
+    version="0.3.3-2",
     entry_points={"console_scripts": ["controller = controller:main"]},
     description="Carbonio Preview.",
     long_description=open("README.md").read(),

--- a/tests/core/services/document_manipulation/test_document_manipulation.py
+++ b/tests/core/services/document_manipulation/test_document_manipulation.py
@@ -4,205 +4,70 @@
 
 import io
 import pytest
-from typing import List
-from unittest import IsolatedAsyncioTestCase
-from unittest.mock import MagicMock, patch
+
 from app.core.services.document_manipulation import document_manipulation  # noqa
 
 
-class TestPdfManipulation(IsolatedAsyncioTestCase):
-    encrypted_pdf_mock = MagicMock(return_value=b"encrypted_sample")
-    encrypted_pdf_mock.keys = MagicMock(return_value=["key1", "/Encrypt", "key2"])
-
-    def setUp(self) -> None:
-        super(TestPdfManipulation, self).setUp()
-
-    def tearDown(self) -> None:
-        super(TestPdfManipulation, self).tearDown()
-
-    def test_parse_if_valid_pdf_not_valid(self):
-        buf: bytes = b""
-        result = document_manipulation._parse_if_valid_pdf(buf)
-        self.assertEqual(result, None)
-
-    def test_parse_if_valid_pdf_valid(self):
-        mock_pdfreader = MagicMock()
-        document_manipulation.PdfReader = mock_pdfreader
-        buf: bytes = b""
-        result = document_manipulation._parse_if_valid_pdf(buf)
-        self.assertNotEqual(result, None)
-
-    @patch(
-        "app.core.services.document_manipulation.document_manipulation._parse_if_valid_pdf",
-        return_value=None,
-    )
-    @patch(
-        "app.core.services.document_manipulation.document_manipulation._get_sanitize_offset",
-        return_value=0,
-    )
-    def test_split_pdf_invalid_pdf(self, mock_sanitize_offset, mock_parse_pdf):
-        # TODO(RakuJa): Remove this empty_pdf_buffer, mock write to buffer and check its input arguments
-        empty_pdf_bytes: bytes = (
-            b"%PDF-1.3\n%\xe2\xe3\xcf\xd3\n1 0 "
-            b"obj\n<</Pages 2 0 R /Type /Catalog>>"
-            b"\nendobj\n2 0 obj\n<</Count 0 /Kids []"
-            b" /Type /Pages>>\nendobj\nxref\n0 3\n0000000000"
-            b" 65535 f\r\n0000000015 00000 n\r\n0000000062"
-            b" 00000 n\r\ntrailer\n\n<</Root 1 0 R "
-            b"/Size 3>>\nstartxref\n112\n%%EOF\n"
-        )
-        result = document_manipulation.split_pdf(io.BytesIO(), 0, 1)
-        self.assertEqual(result.read(), empty_pdf_bytes)
-        self.assertEqual(mock_parse_pdf.call_count, 1)
-        self.assertEqual(mock_sanitize_offset.call_count, 1)
-
-    @patch(
-        "app.core.services.document_manipulation.document_manipulation._parse_if_valid_pdf",
-        return_value=True,
-    )
-    @patch(
-        "app.core.services.document_manipulation.document_manipulation._get_sanitize_offset",
-        return_value=0,
-    )
-    def test_split_pdf_valid_pdf_no_pages_to_split(
-        self, mock_sanitize_offset, mock_parse_pdf
-    ):
-        result = document_manipulation.split_pdf(io.BytesIO(), 1, 0)
-        self.assertEqual(result.read(), b"")
-        self.assertEqual(mock_parse_pdf.call_count, 1)
-        self.assertEqual(mock_sanitize_offset.call_count, 1)
-
-    @patch(
-        "app.core.services.document_manipulation.document_manipulation._parse_if_valid_pdf",
-        return_value=encrypted_pdf_mock,
-    )
-    @patch(
-        "app.core.services.document_manipulation.document_manipulation._get_sanitize_offset",
-        return_value=0,
-    )
-    def test_split_encrypted_pdf(self, mock_sanitize_offset, mock_parse_pdf):
-        result = document_manipulation.split_pdf(io.BytesIO(b"ciao"), 2, 5)
-        self.assertEqual(result.read(), b"ciao")
-        self.assertEqual(mock_parse_pdf.call_count, 1)
-        self.assertEqual(mock_sanitize_offset.call_count, 1)
-
-
-def test_given_pdf_without_extra_headers_sanitize_offset_should_return_0(expect):
+def test_parse_if_valid_pdf_not_valid():
     # Given
-    buff_argument = io.BytesIO()
-    pdf_content: List[bytes] = [b"%PDF-1.5", b"pdf_content1", b"pdf_content2"]
-    expect(document_manipulation, times=1)._read_buffer_line_by_line(
-        buff_argument
-    ).thenReturn(pdf_content)
+    buf: io.BytesIO = io.BytesIO(b"")
 
     # When
-    result = document_manipulation._get_sanitize_offset(buff_argument)
+    result = document_manipulation._parse_if_valid_pdf(buf)
 
     # Then
-    assert result == 0
+    assert result is None
 
 
-def test_given_pdf_with_one_extra_headers_sanitize_offset_should_return_len_first_string(
-    expect,
-):
+def test_split_pdf_invalid_pdf(expect):
     # Given
+    empty_pdf = b"%PDF-1.7"
     buff_argument = io.BytesIO()
-    pdf_content: List[bytes] = [b"extra-header" b"%PDF-1.5", b"pdf_content1"]
-    expect(document_manipulation, times=1)._read_buffer_line_by_line(
+    expect(document_manipulation, times=1)._parse_if_valid_pdf(
         buff_argument
-    ).thenReturn(pdf_content)
+    ).thenReturn(None)
+    expect(document_manipulation, times=1)._write_pdf_to_buffer(None).thenReturn(
+        empty_pdf
+    )
 
     # When
-    result = document_manipulation._get_sanitize_offset(buff_argument)
+    result = document_manipulation.split_pdf(buff_argument, 0, 1)
 
     # Then
-    assert result == 12
+    assert result is empty_pdf
+
+
+def test_split_pdf_valid_pdf_no_pages_to_split(expect):
+    # Given
+    buff_argument = io.BytesIO()
+    expect(document_manipulation, times=1)._parse_if_valid_pdf(
+        buff_argument
+    ).thenReturn(True)
+
+    # When
+    result = document_manipulation.split_pdf(buff_argument, 1, 0)
+
+    # Then
+    assert result.read() is b""
 
 
 @pytest.mark.parametrize(
-    "in_out_tuple",
+    "in_out_extensions_tuple",
     [
-        ([b"x%PDF-1.5"], 1),
-        ([b"xxxx%PDF-1.5"], 4),
-        ([b"xxxxxxxxxxx%PDF-1.5"], 11),
-        ([b"x%PDF-1.5", b"pdf-content"], 1),
-        ([b"pdf-content", b"x%PDF-1.5"], 12),
-        ([b"xxxx%PDF-1.5", b"pdf-content"], 4),
-        ([b"pdf-content", b"xxxx%PDF-1.5"], 15),
-        ([b"xxxxxxxxxxx%PDF-1.5", b"pdf-content"], 11),
-        ([b"pdf-content", b"xxxxxxxxxxx%PDF-1.5"], 22),
+        ("jpeg", "png"),
+        ("JPEG", "png"),
+        ("png", "png"),
+        ("PNG", "png"),
+        ("other_ext", "other_ext"),
     ],
 )
-def test_given_pdf_with_extra_headers_sanitize_offset_should_return_correct_size(
-    expect, in_out_tuple
-):
+def test_sanitize_libre_extension(expect, in_out_extensions_tuple):
     # Given
-    buff_argument = io.BytesIO()
-    expect(document_manipulation, times=1)._read_buffer_line_by_line(
-        buff_argument
-    ).thenReturn(in_out_tuple[0])
+    input_format = in_out_extensions_tuple[0]
+    output_format = in_out_extensions_tuple[1]
 
     # When
-    result = document_manipulation._get_sanitize_offset(buff_argument)
+    result = document_manipulation._sanitize_output_extension(input_format)
 
     # Then
-    assert result is in_out_tuple[1]
-
-
-def test_given_pdf_without_correct_header_and_multiple_lines_offset_should_return_str_size(
-    expect,
-):
-    # Given
-    buff_argument = io.BytesIO()
-    str_to_search = [b"zextras", b"-", b"test-rakuja"]
-    expect(document_manipulation, times=1)._read_buffer_line_by_line(
-        buff_argument
-    ).thenReturn(str_to_search)
-
-    # When
-    result = document_manipulation._get_sanitize_offset(buff_argument)
-
-    # Then
-    assert result is sum(len(x) for x in str_to_search)
-
-
-def test_given_pdf_without_correct_header_and_single_line_offset_should_return_str_size(
-    expect,
-):
-    # Given
-    buff_argument = io.BytesIO()
-    str_to_search = b"zextras-test-rakuja"
-    expect(document_manipulation, times=1)._read_buffer_line_by_line(
-        buff_argument
-    ).thenReturn([str_to_search])
-
-    # When
-    result = document_manipulation._get_sanitize_offset(buff_argument)
-
-    # Then
-    assert result is len(str_to_search)
-
-
-def test_given_empty_buffer_read_by_line_should_return_nothing():
-    # Given
-    buff_argument = io.BytesIO()
-
-    # When
-    result = document_manipulation._read_buffer_line_by_line(buff_argument)
-
-    # Then
-    with pytest.raises(StopIteration) as e_info:
-        next(result)
-    assert e_info.value.value is None
-
-
-def test_given_buffer_with_one_line_read_by_line_should_return_one_line():
-    # Given
-    buff_argument = io.BytesIO(b"first-line")
-
-    # When
-    result = document_manipulation._read_buffer_line_by_line(buff_argument)
-
-    # Then
-    for line in result:
-        assert b"first-line" == line
+    assert result is output_format


### PR DESCRIPTION
# Description

 * use pypdfium2 even for pdf split.
 * refactor document_manipulation tests using pytest
 * remove utility method used to fix some pdfrw bugs
 * remove pdfrw from THIRDPARTIES

## Type of change

Please delete options that are not relevant or put an 'x' on the desired options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update
# Checklist:

This checklist is used as a reminder to avoid half-baked code
- [x] The PR title follows the following structure:" type[optional scope]: PREV-XX - LONG DESCRIPTION "
- [x] I have bumped both the PKGBUILD version and controller version, and they are the same.
- [x] I have correctly installed and enabled pre-commit
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] If I have introduced new dependencies I have added them to the pre-commit unittest additional_dependencies AND to the THIRDPARTIES file