### PR TITLE
build(deps): bump pypdfium2 to 4.26.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ gunicorn~=20.1.0
 httpx~=0.24.1
 
 Pillow~=10.0.0
-pypdfium2~=4.18.0
+pypdfium2~=4.26.0
 
 psutil==5.9.5
 


### PR DESCRIPTION
# Description

Update pypdfium2 dependency to 4.26.0 version due to a linkage problem with ctypesgen.

## Type of change

Please delete options that are not relevant or put an 'x' on the desired options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update