### PR TITLE
feat: use custom language to return preview of documents

### DIFF
--- a/app/controller.py
+++ b/app/controller.py
@@ -15,7 +15,7 @@ from app.core.routers import document, health, image, pdf
 
 app = FastAPI(
     title=SERVICE_NAME,
-    version="0.3.10-SNAPSHOT",
+    version="0.3.11-SNAPSHOT",
     description=SERVICE_DESCRIPTION,
 )
 

--- a/app/core/routers/document.py
+++ b/app/core/routers/document.py
@@ -48,7 +48,7 @@ async def get_preview(
         id: UUID,
         version: NonNegativeInt,
         service_type: ServiceTypeEnum,
-        locale: str,
+        locale: str = "en-US",
         pages: DocumentPagesMetadataModel = Depends(),
 ) -> Response:
     """

--- a/app/core/routers/document.py
+++ b/app/core/routers/document.py
@@ -45,10 +45,11 @@ router = APIRouter(
     },
 )
 async def get_preview(
-    id: UUID,
-    version: NonNegativeInt,
-    service_type: ServiceTypeEnum,
-    pages: DocumentPagesMetadataModel = Depends(),
+        id: UUID,
+        version: NonNegativeInt,
+        service_type: ServiceTypeEnum,
+        locale: str,
+        pages: DocumentPagesMetadataModel = Depends(),
 ) -> Response:
     """
     Create and returns a pdf preview of the given file,
@@ -61,6 +62,7 @@ async def get_preview(
     - **service_type**: Service that owns the resource
     (service that first uploaded the data to storage)
     \f
+    :param locale:
     :param id: UUID of the file
     :param pages: first and last page to convert
     :param version: version of the file
@@ -68,7 +70,6 @@ async def get_preview(
     :return: 400 if there were invalid parameters, otherwise
     the requested file converted accordingly to pdf.
     """
-
     return get_document_preview_enabled_response_error().value_or(
         await document_service.retrieve_doc_and_create_preview(
             file_id=str(id),
@@ -76,14 +77,16 @@ async def get_preview(
             first_page_number=pages.first_page,
             last_page_number=pages.last_page,
             service_type=service_type,
+            locale=locale
         ),
     )
 
 
 @router.post("/")
 async def post_preview(
-    file: UploadFile,
-    pages: DocumentPagesMetadataModel = Depends(),
+        file: UploadFile,
+        pages: DocumentPagesMetadataModel = Depends(),
+        locale: str = "en-US",
 ) -> Response:
     """
     Create and returns a pdf preview of the given file,
@@ -93,6 +96,7 @@ async def post_preview(
     - **first_page**: integer value of first page to preview (n>=1)
     - **last_page**: integer value of last page to preview  (0 = last of the pdf)
     \f
+    :param locale:
     :param file: file uploaded with FormData
     :param pages: integer value of first page and last page to preview
     :return: 400 if there were invalid parameters, otherwise
@@ -105,6 +109,7 @@ async def post_preview(
                     first_page_number=pages.first_page,
                     last_page_number=pages.last_page,
                     file=file,
+                    locale=locale,
                 )
             ).read(),
             media_type="application/pdf",
@@ -117,11 +122,12 @@ async def post_preview(
     responses={status.HTTP_400_BAD_REQUEST: {"description": message.INPUT_ERROR}},
 )
 async def post_thumbnail(
-    area: Annotated[str, Path(regex=AREA_REGEX)],
-    file: UploadFile,
-    shape: ImageBorderShapeEnum = ImageBorderShapeEnum.RECTANGULAR,
-    quality: ImageQualityEnum = ImageQualityEnum.MEDIUM,
-    output_format: ImageTypeEnum = ImageTypeEnum.JPEG,
+        area: Annotated[str, Path(regex=AREA_REGEX)],
+        file: UploadFile,
+        shape: ImageBorderShapeEnum = ImageBorderShapeEnum.RECTANGULAR,
+        quality: ImageQualityEnum = ImageQualityEnum.MEDIUM,
+        output_format: ImageTypeEnum = ImageTypeEnum.JPEG,
+        locale: str = "en-US",
 ) -> Response:
     """
     Create and returns the thumbnail of the given file,
@@ -135,6 +141,7 @@ async def post_thumbnail(
     - **shape**: Rounded and Rectangular are currently supported.
     - **file**: file uploaded with FormData.
     \f
+    :param locale:
     :param shape: Rounded and Rectangular are currently supported
     :param quality: quality of the output image
     :param output_format: format of the output image
@@ -158,6 +165,7 @@ async def post_thumbnail(
     content: io.BytesIO = await document_service.create_thumbnail_from_raw(
         file=file,
         output_format=output_format.value,
+        locale=locale,
     )
     return Response(
         content=(
@@ -179,13 +187,14 @@ async def post_thumbnail(
     },
 )
 async def get_thumbnail(
-    id: UUID,
-    version: NonNegativeInt,
-    area: Annotated[str, Path(regex=AREA_REGEX)],
-    service_type: ServiceTypeEnum,
-    shape: ImageBorderShapeEnum = ImageBorderShapeEnum.RECTANGULAR,
-    quality: ImageQualityEnum = ImageQualityEnum.MEDIUM,
-    output_format: ImageTypeEnum = ImageTypeEnum.JPEG,
+        id: UUID,
+        version: NonNegativeInt,
+        area: Annotated[str, Path(regex=AREA_REGEX)],
+        service_type: ServiceTypeEnum,
+        shape: ImageBorderShapeEnum = ImageBorderShapeEnum.RECTANGULAR,
+        quality: ImageQualityEnum = ImageQualityEnum.MEDIUM,
+        output_format: ImageTypeEnum = ImageTypeEnum.JPEG,
+        locale: str = "en-US",
 ) -> Response:
     """
     Create and returns a thumbnail of the file fetched by id and version
@@ -202,6 +211,7 @@ async def get_thumbnail(
     - **service_type**: Service that owns the resource
      (service that first uploaded the data to storage)
     \f
+    :param locale:
     :param id: UUID of the file
     :param version: version of the file
     :param service_type: service that owns the resource
@@ -229,6 +239,7 @@ async def get_thumbnail(
         version=version,
         output_format=output_format.value,
         service_type=service_type,
+        locale=locale,
     )
     if image_response.status_code == status.HTTP_200_OK:
         image_raw: io.BytesIO = io.BytesIO(image_response.body)

--- a/app/core/routers/document.py
+++ b/app/core/routers/document.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 import io
+import logging
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Path, UploadFile, status
@@ -62,7 +63,7 @@ async def get_preview(
     - **service_type**: Service that owns the resource
     (service that first uploaded the data to storage)
     \f
-    :param locale:
+    :param locale: locale (language tag) to convert document, especially to format dates
     :param id: UUID of the file
     :param pages: first and last page to convert
     :param version: version of the file
@@ -96,7 +97,7 @@ async def post_preview(
     - **first_page**: integer value of first page to preview (n>=1)
     - **last_page**: integer value of last page to preview  (0 = last of the pdf)
     \f
-    :param locale:
+    :param locale: locale (language tag) to convert document, especially to format dates
     :param file: file uploaded with FormData
     :param pages: integer value of first page and last page to preview
     :return: 400 if there were invalid parameters, otherwise
@@ -141,7 +142,7 @@ async def post_thumbnail(
     - **shape**: Rounded and Rectangular are currently supported.
     - **file**: file uploaded with FormData.
     \f
-    :param locale:
+    :param locale: locale (language tag) to convert document, especially to format dates
     :param shape: Rounded and Rectangular are currently supported
     :param quality: quality of the output image
     :param output_format: format of the output image
@@ -211,7 +212,7 @@ async def get_thumbnail(
     - **service_type**: Service that owns the resource
      (service that first uploaded the data to storage)
     \f
-    :param locale:
+    :param locale: locale (language tag) to convert document, especially to format dates
     :param id: UUID of the file
     :param version: version of the file
     :param service_type: service that owns the resource

--- a/app/core/routers/document.py
+++ b/app/core/routers/document.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 import io
-import logging
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Path, UploadFile, status

--- a/app/core/services/document_manipulation/document_manipulation.py
+++ b/app/core/services/document_manipulation/document_manipulation.py
@@ -216,9 +216,9 @@ async def _convert_with_libre(
 ) -> io.BytesIO:
     output_extension = _sanitize_output_extension(output_extension)
 
-    url = f"{DOCUMENT_CONVERSION_FULL_CONVERT_ADDRESS}/{output_extension}&lang={locale}"
+    url = f"{DOCUMENT_CONVERSION_FULL_CONVERT_ADDRESS}/{output_extension}?lang={locale}"
 
-    log.info(f"******************REQUESTED URL*******************: {url}")
+    log.info(f"Requested URL: {url}")
 
     files = {"files": ("docs-editor-file", content)}
     out_data = io.BytesIO()

--- a/app/core/services/document_manipulation/document_manipulation.py
+++ b/app/core/services/document_manipulation/document_manipulation.py
@@ -216,10 +216,9 @@ async def _convert_with_libre(
 ) -> io.BytesIO:
     output_extension = _sanitize_output_extension(output_extension)
 
-    url = f"{DOCUMENT_CONVERSION_FULL_CONVERT_ADDRESS}/{output_extension}?lang={locale}"
+    url = f"{DOCUMENT_CONVERSION_FULL_CONVERT_ADDRESS}/{output_extension}&lang={locale}"
 
-    print("-------------------------------------------------")
-    print(url)
+    print("**********************Requesting:*********************** ", url)
 
     files = {"files": ("docs-editor-file", content)}
     out_data = io.BytesIO()

--- a/app/core/services/document_manipulation/document_manipulation.py
+++ b/app/core/services/document_manipulation/document_manipulation.py
@@ -218,7 +218,7 @@ async def _convert_with_libre(
 
     url = f"{DOCUMENT_CONVERSION_FULL_CONVERT_ADDRESS}/{output_extension}&lang={locale}"
 
-    print("**********************Requesting:*********************** ", url)
+    log.info(f"******************REQUESTED URL*******************: {url}")
 
     files = {"files": ("docs-editor-file", content)}
     out_data = io.BytesIO()

--- a/app/core/services/document_manipulation/document_manipulation.py
+++ b/app/core/services/document_manipulation/document_manipulation.py
@@ -89,11 +89,13 @@ async def convert_to_pdf(
     content: io.BytesIO,
     first_page_number: int,
     last_page_number: int,
+    locale: str,
     log: logging.Logger = logger,
 ) -> io.BytesIO:
     """
     Converts any Carbonio-docs-editor supported format to pdf
     \f
+    :param locale:
     :param content: file to convert
     :param first_page_number: first page to convert
     :param last_page_number: last page to convert
@@ -104,6 +106,7 @@ async def convert_to_pdf(
         content=await convert_file_to(
             content=content,
             output_extension="pdf",
+            locale=locale,
             log=log,
         ),
         first_page_number=first_page_number,
@@ -114,6 +117,7 @@ async def convert_to_pdf(
 async def convert_file_to(
     content: io.BytesIO,
     output_extension: str,
+    locale: str,
     log: logging.Logger = logger,
 ) -> io.BytesIO:
     """
@@ -122,6 +126,7 @@ async def convert_file_to(
      SHOULD ALWAYS be used instead of _convert_with_libre
      as it isolates the connection with libre
     \f
+    :param locale:
     :param content: file to convert
     :param output_extension: output file,
      should be a format supported by Carbonio-docs-editor
@@ -130,6 +135,7 @@ async def convert_file_to(
     return await _convert_with_libre(
         content=content,
         output_extension=output_extension,
+        locale=locale,
         log=log,
     )
 
@@ -176,11 +182,13 @@ async def convert_pdf_to(
     output_extension: str,
     first_page_number: int,
     last_page_number: int,
+    locale: str,
     log: logging.Logger = logger,
 ) -> io.BytesIO:
     """
     Converts pdf to any Carbonio-docs-editor supported format
     \f
+    :param locale:
     :param content: pdf to convert
     :param output_extension: desired file output type
     :param first_page_number: first page to convert
@@ -195,6 +203,7 @@ async def convert_pdf_to(
     return await convert_file_to(
         content=out_content,
         output_extension=output_extension,
+        locale=locale,
         log=log,
     )
 
@@ -202,11 +211,15 @@ async def convert_pdf_to(
 async def _convert_with_libre(
     content: io.BytesIO,
     output_extension: str,
+    locale: str,
     log: logging.Logger,
 ) -> io.BytesIO:
     output_extension = _sanitize_output_extension(output_extension)
 
-    url = f"{DOCUMENT_CONVERSION_FULL_CONVERT_ADDRESS}/{output_extension}"
+    url = f"{DOCUMENT_CONVERSION_FULL_CONVERT_ADDRESS}/{output_extension}?lang={locale}"
+
+    print("-------------------------------------------------")
+    print(url)
 
     files = {"files": ("docs-editor-file", content)}
     out_data = io.BytesIO()

--- a/app/core/services/document_service.py
+++ b/app/core/services/document_service.py
@@ -23,12 +23,14 @@ async def retrieve_doc_and_create_preview(
     first_page_number: int,
     last_page_number: int,
     service_type: ServiceTypeEnum,
+    locale: str
 ) -> FastApiResp:
     """
     Contact storage and retrieves the image with the nodeid requested
     and trims it to the number of pages requested.
     If the nodeid is not found returns Generic error specifying the error code
     \f
+    :param locale:
     :param file_id: UUID of the file
     :param version: version of the file
     :param first_page_number: first page to return
@@ -56,6 +58,7 @@ async def retrieve_doc_and_create_preview(
                             RequestResp(status_code=status.HTTP_200_OK),
                         ).content,
                     ),
+                    locale=locale,
                 )
             ).read(),
             media_type="application/pdf",
@@ -67,10 +70,12 @@ async def create_preview_from_raw(
     file: UploadFile,
     first_page_number: int,
     last_page_number: int,
+    locale: str,
 ) -> io.BytesIO:
     """
     Create pdf preview of a given file
     \f
+    :param locale:
     :param file: uploaded file to convert
     :param first_page_number: the first page of the pdf to return
     :param last_page_number: the last page of the pdf to return
@@ -79,19 +84,22 @@ async def create_preview_from_raw(
         first_page_number=first_page_number,
         last_page_number=last_page_number,
         content=io.BytesIO(file.file.read()),
+        locale=locale,
     )
 
 
-async def create_thumbnail_from_raw(file: UploadFile, output_format: str) -> io.BytesIO:
+async def create_thumbnail_from_raw(file: UploadFile, output_format: str, locale: str) -> io.BytesIO:
     """
     Create image thumbnail of a given file
     \f
+    :param locale:
     :param file: uploaded file to convert
     :param output_format: the image type that the thumbnail will have
     """
     return await document_manipulation.convert_file_to(
         content=io.BytesIO(file.file.read()),
         output_extension=output_format,
+        locale=locale
     )
 
 
@@ -100,12 +108,14 @@ async def retrieve_doc_and_create_thumbnail(
     version: int,
     output_format: str,
     service_type: ServiceTypeEnum,
+    locale: str,
 ) -> FastApiResp:
     """
     Contact storage and retrieves the document
      with the nodeid requested and converts it to image.
     If the nodeid is not found returns Generic error specifying the error code
     \f
+    :param locale:
     :param file_id: UUID of the file
     :param version: version of the file
     :param output_format: format
@@ -131,6 +141,7 @@ async def retrieve_doc_and_create_thumbnail(
                         ).content,
                     ),
                     output_extension=output_format,
+                    locale=locale
                 )
             ).read(),
             media_type=f"image/{output_format}",

--- a/package/preview/PKGBUILD
+++ b/package/preview/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname="carbonio-preview-ce"
-pkgver="0.3.10"
+pkgver="0.3.11"
 pkgrel="SNAPSHOT"
 pkgdesc="Carbonio Preview"
 maintainer="Zextras <packages@zextras.com>"

--- a/rest-api.yaml
+++ b/rest-api.yaml
@@ -6,7 +6,7 @@ openapi: 3.0.2
 info:
   title: preview
   description: "\nPreview service. \U0001F680 \n\nYou can preview the following type of files:\n\n* **images(png/jpeg/gif)**\n* **pdf**\n* **documents (xls, xlsx, ods, ppt, pptx, odp, doc, docx, odt)**\n\nYou will be able to:\n\n* **Preview images**.\n* **Generate smart thumbnails**.\n\nThe main difference between thumbnail and preview\n functionality is that preview tends to be more faithful\nwhile thumbnail tends to elaborate on it, cropping\n it by default and rounding the image if asked.\nPreview should always output the file in its original format,\n while thumbnail will convert it to an image.\nThere is no difference in quality between png and jpeg,\n the difference in quality can be achieved only\nby asking for a jpeg format and changing the quality parameter.\n Asking for a GIF output can only be done when the input file is a GIF, otherwise it will raise and error.\n"
-  version: 0.3.5-1
+  version: 0.3.11-SNAPSHOT
 paths:
   '/preview/image/{id}/{version}/{area}/thumbnail/':
     get:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with Path.open(Path(this_directory, "README.md"), encoding="utf-8") as f:
 setup(
     name="carbonio-preview-ce",
     packages=find_packages(),
-    version="0.3.5-1",
+    version="0.3.11-SNAPSHOT",
     entry_points={"console_scripts": ["controller = controller:main"]},
     description="Carbonio Preview.",
     long_description=Path.open(Path("README.md")).read(),


### PR DESCRIPTION
- Pass custom language to docs-editor when converting document to return preview

Depends from:
[carbonio-files-ce#106](https://github.com/zextras/carbonio-files-ce/pull/106)
[carbonio-docs-editor#16](https://github.com/zextras/carbonio-docs-editor/pull/16)
[carbonio-user-management#43](https://github.com/zextras/carbonio-user-management/pull/43)
[carbonio-preview-sdk#12](https://github.com/zextras/carbonio-preview-sdk/pull/12)

Refs: PREV-128