### PR TITLE
build(deps): updated all dependencies

### DIFF
--- a/app/controller.py
+++ b/app/controller.py
@@ -15,7 +15,7 @@ from app.core.routers import document, health, image, pdf
 
 app = FastAPI(
     title=SERVICE_NAME,
-    version="0.5.0-1",
+    version="0.5.1-SNAPSHOT",
     description=SERVICE_DESCRIPTION,
 )
 

--- a/package/preview/PKGBUILD
+++ b/package/preview/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname="carbonio-preview-ce"
-pkgver="0.5.0"
-pkgrel="1"
+pkgver="0.5.1"
+pkgrel="SNAPSHOT"
 pkgdesc="Carbonio Preview"
 maintainer="Zextras <packages@zextras.com>"
 copyright=(

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 FastAPI~=0.112.3
 
 pydantic>=2.8.2
-returns~=0.23.0
+returns~=0.22.0
 
 uvicorn~=0.30.6
 gunicorn~=23.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,20 +2,20 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-FastAPI~=0.109.2
+FastAPI~=0.112.3
 
-pydantic>=2.6.2
-returns~=0.22.0
+pydantic>=2.8.2
+returns~=0.23.0
 
-uvicorn~=0.27.1
-gunicorn~=21.2.0
+uvicorn~=0.30.6
+gunicorn~=23.0.0
 
-httpx~=0.26.0
+httpx~=0.27.2
 
-Pillow~=10.2.0
-pypdfium2~=4.27.0
+Pillow~=10.4.0
+pypdfium2~=4.30.0
 
-psutil==5.9.8
+psutil==6.0.0
 
 python-multipart==0.0.9
 

--- a/rest-api.yaml
+++ b/rest-api.yaml
@@ -6,7 +6,7 @@ openapi: 3.0.2
 info:
   title: preview
   description: "\nPreview service. \U0001F680 \n\nYou can preview the following type of files:\n\n* **images(png/jpeg/gif/svg)**\n* **pdf**\n* **documents (xls, xlsx, ods, ppt, pptx, odp, doc, docx, odt)**\n\nYou will be able to:\n\n* **Preview images**.\n* **Generate smart thumbnails**.\n\nThe main difference between thumbnail and preview\n functionality is that preview tends to be more faithful\nwhile thumbnail tends to elaborate on it, cropping\n it by default and rounding the image if asked.\nPreview should always output the file in its original format,\n while thumbnail will convert it to an image.\nThere is no difference in quality between png and jpeg,\n the difference in quality can be achieved only\nby asking for a jpeg format and changing the quality parameter.\n Asking for a GIF output can only be done when the input file is a GIF, otherwise it will raise and error.\n"
-  version: 0.5.0
+  version: 0.5.1
 paths:
   '/preview/image/{id}/{version}/{area}/thumbnail/':
     get:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with Path.open(Path(this_directory, "README.md"), encoding="utf-8") as f:
 setup(
     name="carbonio-preview-ce",
     packages=find_packages(),
-    version="0.5.0",
+    version="0.5.1",
     entry_points={"console_scripts": ["controller = controller:main"]},
     description="Carbonio Preview.",
     long_description=Path.open(Path("README.md")).read(),


### PR DESCRIPTION
Updated all dependencies to their last version:
- FastAPI: 0.109.2 -> 0.112.3
- pydantic: 2.6.2 -> 2.8.2
- uvicorn: 0.27.1 -> 0.30.6
- gunicorn: 21.2.0 -> 23.0.0
- httpx: 0.26.0 -> 0.27.2
- Pillow: 10.2.0 -> 10.4.0
- pypdfium2: 4.27.0 -> 4.30.0
- psutil: 5.9.8 -> 6.0.0

Refs: PREV-142