### PR TITLE
fix: return a 404 or 422 status code when storages APIs fails 

### DIFF
--- a/app/core/resources/app_config.py
+++ b/app/core/resources/app_config.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
 import ipaddress
 from pathlib import Path
 from typing import Final
@@ -12,51 +16,58 @@ def validate_ip(value: str) -> str:
     try:
         ipaddress.ip_address(value)
     except ValueError:
-        raise ValueError(f"Invalid IP address: {value}")
+        msg = f"Invalid IP address: {value}"
+        raise ValueError(msg)
     return value
 
 
 def validate_log_level(value: str) -> str:
     if value.upper() not in ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]:
-        raise ValueError(f"Log level is not valid. Given value {value}")
+        msg = f"Log level is not valid. Given value {value}"
+        raise ValueError(msg)
     return value
 
 
 def validate_log_path(value: str) -> str:
     if not Path(value).resolve().exists():
-        raise ValueError("Log path is not valid or does not exist.")
+        msg = "Log path is not valid or does not exist."
+        raise ValueError(msg)
     return value
 
 
 def validate_positive_int(value) -> int:
     value = int(value)
     if value <= 0:
-        raise ValueError(f"Value must be a positive integer. Given value {value}")
+        msg = f"Value must be a positive integer. Given value {value}"
+        raise ValueError(msg)
     return value
 
 
 def validate_non_negative_int(value) -> int:
     value = int(value)
     if value < 0:
-        raise ValueError(f"Value must be a non-negative integer. Given value {value}")
+        msg = f"Value must be a non-negative integer. Given value {value}"
+        raise ValueError(msg)
     return value
 
 
 def validate_port(value) -> int:
     value = int(value)
     if not (PORT_MIN_NUMBER <= value <= PORT_MAX_NUMBER):
-        raise ValueError(
-            f"Port number must be between {PORT_MIN_NUMBER} and {PORT_MAX_NUMBER}. Given value {value}")
+        msg = f"Port number must be between {PORT_MIN_NUMBER} and {PORT_MAX_NUMBER}. Given value {value}"
+        raise ValueError(msg)
     return value
 
 
 class AppConfig:
-    def __init__(self, config: dict):
+    def __init__(self, config: dict) -> None:
         # Service
         self.service_name: str = config["service_name"]
         self.service_ip: str = validate_ip(config["service_ip"])
         self.service_port: int = validate_port(config["service_port"])
-        self.service_timeout_in_seconds: int = validate_positive_int(config["service_timeout_in_seconds"])
+        self.service_timeout_in_seconds: int = validate_positive_int(
+            config["service_timeout_in_seconds"],
+        )
 
         self.number_of_workers: int = validate_positive_int(config["service_workers"])
 
@@ -65,10 +76,18 @@ class AppConfig:
         self.service_pdf_name: str = config["service_pdf_name"]
         self.service_document_name: str = config["service_document_name"]
 
-        self.enable_document_preview: bool = config.get("service_enable_document_preview", True)
-        self.enable_document_thumbnail: bool = config.get("service_enable_document_thumbnail", False)
+        self.enable_document_preview: bool = config.get(
+            "service_enable_document_preview",
+            True,
+        )
+        self.enable_document_thumbnail: bool = config.get(
+            "service_enable_document_thumbnail",
+            False,
+        )
 
-        self.docs_timeout: int = validate_positive_int(config.get("service_docs-timeout", 5))
+        self.docs_timeout: int = validate_positive_int(
+            config.get("service_docs-timeout", 5),
+        )
 
         # Log
         self.log_path: str = validate_log_path(config["log_path"])
@@ -76,7 +95,9 @@ class AppConfig:
         self.log_level: str = validate_log_level(config["log_level"])
 
         # Image
-        self.image_constants_minimum_resolution: int = validate_non_negative_int(config["image_constants_minimum_resolution"])
+        self.image_constants_minimum_resolution: int = validate_non_negative_int(
+            config["image_constants_minimum_resolution"],
+        )
 
         # Storage
         self.storage_name: str = config["storage_name"]
@@ -90,10 +111,16 @@ class AppConfig:
         # Document conversion
         self.document_conversion_protocol: str = config["document_conversion_protocol"]
         self.document_conversion_ip: str = validate_ip(config["document_conversion_ip"])
-        self.document_conversion_port: int = validate_port(config["document_conversion_port"])
+        self.document_conversion_port: int = validate_port(
+            config["document_conversion_port"],
+        )
 
-        self.document_conversion_service_endpoint: str = config["document_conversion_service_endpoint"]
-        self.document_conversion_convert_api: str = config["document_conversion_convert_api"]
+        self.document_conversion_service_endpoint: str = config[
+            "document_conversion_service_endpoint"
+        ]
+        self.document_conversion_convert_api: str = config[
+            "document_conversion_convert_api"
+        ]
 
 
 # LOAD CONFIG

--- a/app/core/resources/data_validator.py
+++ b/app/core/resources/data_validator.py
@@ -81,16 +81,17 @@ def check_for_storage_response_error(
     """
     status_code = response_data.value_or(
         FastApiResp(
-            status_code=status.HTTP_502_BAD_GATEWAY,
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
         ),
     ).status_code
+
     if status.HTTP_200_OK <= status_code < status.HTTP_400_BAD_REQUEST:
         return Nothing
 
     return Maybe.from_value(
         FastApiResp(
-            content=message.STORAGE_UNAVAILABLE_STRING
-            if status_code >= status.HTTP_500_INTERNAL_SERVER_ERROR
+            content=message.ITEM_NOT_FOUND
+            if status_code == status.HTTP_404_NOT_FOUND
             else message.GENERIC_ERROR_WITH_STORAGE,
             status_code=status_code,
         ),

--- a/app/core/services/storage_communication.py
+++ b/app/core/services/storage_communication.py
@@ -12,6 +12,8 @@ from app.core.resources.schemas.enums.service_type_enum import ServiceTypeEnum
 
 logger = logging.getLogger(__name__)
 
+HTTP_404_STATUS_CODE: int = 404
+
 
 async def retrieve_data(
     file_id: str,
@@ -41,7 +43,11 @@ async def retrieve_data(
             return Maybe.from_value(resp)
     except httpx.HTTPStatusError as http_error:
         log.debug(f"Http Error: {http_error} for request {req}")
-        return Nothing
+        return (
+            Maybe.from_value(resp)
+            if resp.status_code == HTTP_404_STATUS_CODE
+            else Nothing
+        )
     # from this onward are not related to the raise_for_status,
     # these are all critical errors.
     except httpx.ConnectTimeout as timeout_error:

--- a/tests/core/services/test_storage_communicator.py
+++ b/tests/core/services/test_storage_communicator.py
@@ -116,3 +116,18 @@ class TestStorageCommunicator(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(0, self.log_mock.error.call_count)
         self.assertEqual(0, self.log_mock.info.call_count)
         self.assertEqual(Nothing, response)
+
+    async def test_retrieve_data_404(self):
+        http_404_error = 404
+        with respx.mock:
+            mock_resp = respx.get(self.req).mock(return_value=Response(http_404_error))
+            response: Optional[Response] = await st_com.retrieve_data(
+                file_id=self.test_id,
+                version=self.version,
+                log=self.log_mock,
+            )
+
+            self.assertEqual(1, mock_resp.call_count)
+            self.assertEqual(1, self.log_mock.debug.call_count)
+            self.assertIsNotNone(response)
+            self.assertEqual(404, response.status_code)


### PR DESCRIPTION
- Updated `storage_communication#retrieve_data`  to handle the 404 HTTP status code returned by carbonio-storages
- Updated `data_validator#check_for_storage_response_error`  to return 422 when the carbonio-storages APIs return a status code other than 200 or 404
- Added the license and formatted the `app_config.py` file

Refs: PREV-144