### PR TITLE
bump(deps): update all dependencies and fix CVEs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,14 +4,14 @@
 
 repos:
 -   repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v2.3.0
+    rev: v4.0.0
     hooks:
     -   id: conventional-pre-commit
         stages: [commit-msg]
         args: []
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.4.1
+    rev: v1.14.1
     hooks:
         - id: mypy
           exclude: ^tests/|gunicorn.conf.py
@@ -21,19 +21,19 @@ repos:
               - "types-Pillow"
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.277
+    rev: v0.9.1
     hooks:
     -   id: ruff
         args: [--fix, --exit-non-zero-on-fix]
 
 
--   repo: https://github.com/python/black.git
-    rev: 23.7.0
+-   repo: https://github.com/python/black
+    rev: 24.10.0
     hooks:
       - id: black
 
 -   repo: https://github.com/fsfe/reuse-tool
-    rev: v1.1.2
+    rev: v5.0.2
     hooks:
         - id: reuse
 
@@ -49,4 +49,4 @@ repos:
         ]
         'types': [python]
         pass_filenames: false
-        stages: [commit]
+        stages: [pre-commit]

--- a/app/controller.py
+++ b/app/controller.py
@@ -15,7 +15,7 @@ from app.core.routers import document, health, image, pdf
 
 app = FastAPI(
     title=SERVICE_NAME,
-    version="0.6.0-1",
+    version="0.6.1-SNAPSHOT",
     description=SERVICE_DESCRIPTION,
 )
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -5,7 +5,7 @@
 -r requirements.txt
 
 black~=24.10.0
-ruff~=0.2.2
+ruff~=0.9.1
 pre-commit~=4.0.1
 
 respx~=0.22.0

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -4,13 +4,13 @@
 
 -r requirements.txt
 
-black~=24.2.0
+black~=24.10.0
 ruff~=0.2.2
-pre-commit~=3.6.1
+pre-commit~=4.0.1
 
-respx~=0.20.2
+respx~=0.22.0
 
-pytest~=8.0.2
+pytest~=8.3.4
 pytest-mockito~=0.0.4
 
-types-Pillow~=10.2.0.20240213
+types-Pillow~=10.2.0.20240822

--- a/package/preview/PKGBUILD
+++ b/package/preview/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname="carbonio-preview-ce"
-pkgver="0.6.0"
-pkgrel="1"
+pkgver="0.6.1"
+pkgrel="SNAPSHOT"
 pkgdesc="Carbonio Preview"
 maintainer="Zextras <packages@zextras.com>"
 copyright=(

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,21 +2,21 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-FastAPI~=0.112.3
+FastAPI~=0.115.6
 
-pydantic>=2.8.2
-returns~=0.22.0
+pydantic>=2.10.5
+returns~=0.24.0
 
-uvicorn~=0.30.6
+uvicorn~=0.34.0
 gunicorn~=23.0.0
 
-httpx~=0.27.2
+httpx~=0.28.1
 
-Pillow~=10.4.0
-pypdfium2~=4.30.0
+Pillow~=11.1.0
+pypdfium2~=4.30.1
 
-psutil==6.0.0
+psutil==6.1.1
 
-python-multipart==0.0.9
+python-multipart==0.0.20
 
 CairoSVG==2.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,9 @@ FastAPI~=0.115.6
 
 pydantic>=2.10.5
 
-# 0.24.0 cannot be used since the drop support for python3.9
-returns~=0.23.0
+# 0.23.0 cannot be used since they drop support for ubuntu20.04
+# 0.24.0 cannot be used since they drop support for python3.9
+returns~=0.22.0
 
 uvicorn~=0.34.0
 gunicorn~=23.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,9 @@
 FastAPI~=0.115.6
 
 pydantic>=2.10.5
-returns~=0.24.0
+
+# 0.24.0 cannot be used since the drop support for python3.9
+returns~=0.23.0
 
 uvicorn~=0.34.0
 gunicorn~=23.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,12 +10,14 @@ pydantic>=2.10.5
 # 0.24.0 cannot be used since they drop support for python3.9
 returns~=0.22.0
 
-uvicorn~=0.34.0
+# 0.34.0 cannot be used since they drop support for python3.8
+uvicorn~=0.33.0
 gunicorn~=23.0.0
 
 httpx~=0.28.1
 
-Pillow~=11.1.0
+# 11.x cannot be used since they drop support for python3.8
+Pillow~=10.4.0
 pypdfium2~=4.30.1
 
 psutil==6.1.1

--- a/rest-api.yaml
+++ b/rest-api.yaml
@@ -6,7 +6,7 @@ openapi: 3.0.2
 info:
   title: preview
   description: "\nPreview service. \U0001F680 \n\nYou can preview the following type of files:\n\n* **images(png/jpeg/gif/svg)**\n* **pdf**\n* **documents (xls, xlsx, ods, ppt, pptx, odp, doc, docx, odt)**\n\nYou will be able to:\n\n* **Preview images**.\n* **Generate smart thumbnails**.\n\nThe main difference between thumbnail and preview\n functionality is that preview tends to be more faithful\nwhile thumbnail tends to elaborate on it, cropping\n it by default and rounding the image if asked.\nPreview should always output the file in its original format,\n while thumbnail will convert it to an image.\nThere is no difference in quality between png and jpeg,\n the difference in quality can be achieved only\nby asking for a jpeg format and changing the quality parameter.\n Asking for a GIF output can only be done when the input file is a GIF, otherwise it will raise and error.\n"
-  version: 0.6.0-1
+  version: 0.6.1-SNAPSHOT
 paths:
   '/preview/image/{id}/{version}/{area}/thumbnail/':
     get:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with Path.open(Path(this_directory, "README.md"), encoding="utf-8") as f:
 setup(
     name="carbonio-preview-ce",
     packages=find_packages(),
-    version="0.6.0",
+    version="0.6.1",
     entry_points={"console_scripts": ["controller = controller:main"]},
     description="Carbonio Preview.",
     long_description=Path.open(Path("README.md")).read(),


### PR DESCRIPTION
Updated all dependencies to their last version where possible:
- black: 24.2.0 → 24.10.0 ([CVE-2024-21503](https://github.com/advisories/GHSA-fj7x-q9j7-g6q6) fixed)
- FastAPI: 0.112.3 → 0.115.6
- pydantic: 2.8.2 → 2.10.5
- returns: 0.22.0 → not updated to 0.24.0 (they drop support for ubuntu20.04 and python3.9)
- uvicorn: 0.30.6 → 0.33.0 (not updated to 0.34.0 since they drop support for python3.8)
- httpx: 0.27.2 → 0.28.1
- Pillow: 10.4.0 → not updated to 11.x (they drop support for python3.8)
- pre-commit: 3.6.1 → 4.0.1
- pypdfium2: 4.30.0 → 4.30.1
- psutil: 6.0.0 → 6.1.1
- pytest: 8.0.2 → 8.3.4
- python-multipart: 0.0.9 → 0.0.20 ([CVE-2024-53981](https://github.com/advisories/GHSA-59g5-xgcq-4qw3) fixed)
- respx: 0.20.2 → 0.22.0
- ruff: 0.2.2 → 0.9.1
- types-Pillow: 10.2.0.20240213 → 10.2.0.20240822 

Refs: PREV-147