### PR TITLE
chore: IN-881 - carbonio.target should restart the services not covered by zmcontrol

### DIFF
--- a/app/controller.py
+++ b/app/controller.py
@@ -15,7 +15,7 @@ from app.core.routers import document, health, image, pdf
 
 app = FastAPI(
     title=SERVICE_NAME,
-    version="0.6.4-SNAPSHOT",
+    version="0.6.5-SNAPSHOT",
     description=SERVICE_DESCRIPTION,
 )
 

--- a/package/preview/PKGBUILD
+++ b/package/preview/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname="carbonio-preview-ce"
-pkgver="0.6.4"
+pkgver="0.6.5"
 pkgrel="SNAPSHOT"
 pkgdesc="Carbonio Preview"
 maintainer="Zextras <packages@zextras.com>"
@@ -59,8 +59,9 @@ source=(
   "policies.json"
   "service-protocol.json"
 )
-sha256sums=('5c378a420cf3eb217fef72ce589d6dbee0ca6c0a054983a12287f92418e96ad5'
-  '731e767bd1165f083420e23fa64f9e19ee518d823b685ecc4b78dada1b271792'
+sha256sums=(
+  'a03162e30a793e180a4344f41c957c15e835c1ac55e6b5867b38aedd8f3156f7'
+  '93300f09c16912e9ba97967798c21f95ec143a0cb5deb9b91c8e09ed396a176a'
   'eaa158e0e71e93fd39b03750d1468dd9f8066891f9682209bde10547d36c1094'
   'cb294a1038886d60c4056a2b50ce8e49d923ad8d15226af4e742a7ae1f5523d6'
   'f70942e22cffaa1b3783aece6275050cb70239573961c5c0cca30f83b5ba58ad'
@@ -68,7 +69,8 @@ sha256sums=('5c378a420cf3eb217fef72ce589d6dbee0ca6c0a054983a12287f92418e96ad5'
   'e193105f8e0710525b696ac9236f9c24e42f2b9fe1e8950331bc2026d9e698f2'
   '17aa6d19c18fcb58b11cd04ddc12e9aea89381453555f8095d8b875a27f5d639'
   '7c3dd74a3bab5260cea7b4876a8e472bc3258cc5bf35ebf3d02dae02d7c02ece'
-  '1d2e022f32d45f5d5b1118fb524f4bafacc92689b76e7f24eea37b9fed6286fe')
+  '1d2e022f32d45f5d5b1118fb524f4bafacc92689b76e7f24eea37b9fed6286fe'
+)
 
 backup=(
   "etc/zextras/service-discover/carbonio-preview.hcl"

--- a/package/preview/carbonio-preview-sidecar.service
+++ b/package/preview/carbonio-preview-sidecar.service
@@ -7,6 +7,7 @@ Description=Carbonio Preview sidecar proxy
 Documentation=https://docs.zextras.com/zextras-suite-documentation/latest/
 Requires=network-online.target
 After=network-online.target
+PartOf=carbonio.target
 
 [Service]
 Type=simple
@@ -24,4 +25,4 @@ TimeoutSec=120
 TimeoutStopSec=120
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=carbonio.target

--- a/package/preview/carbonio-preview.service
+++ b/package/preview/carbonio-preview.service
@@ -7,6 +7,8 @@ Description=Carbonio Preview daemon
 Documentation=https://docs.zextras.com/zextras-suite-documentation/latest/
 Requires=network-online.target
 After=network-online.target
+PartOf=carbonio.target
+
 
 [Service]
 Type=simple
@@ -19,4 +21,4 @@ TimeoutSec=120
 TimeoutStopSec=120
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=carbonio.target

--- a/rest-api.yaml
+++ b/rest-api.yaml
@@ -6,7 +6,7 @@ openapi: 3.0.2
 info:
   title: preview
   description: "\nPreview service. \U0001F680 \n\nYou can preview the following type of files:\n\n* **images(png/jpeg/gif/svg)**\n* **pdf**\n* **documents (xls, xlsx, ods, ppt, pptx, odp, doc, docx, odt)**\n\nYou will be able to:\n\n* **Preview images**.\n* **Generate smart thumbnails**.\n\nThe main difference between thumbnail and preview\n functionality is that preview tends to be more faithful\nwhile thumbnail tends to elaborate on it, cropping\n it by default and rounding the image if asked.\nPreview should always output the file in its original format,\n while thumbnail will convert it to an image.\nThere is no difference in quality between png and jpeg,\n the difference in quality can be achieved only\nby asking for a jpeg format and changing the quality parameter.\n Asking for a GIF output can only be done when the input file is a GIF, otherwise it will raise and error.\n"
-  version: 0.6.4-SNAPSHOT
+  version: 0.6.5-SNAPSHOT
 paths:
   '/preview/image/{id}/{version}/{area}/thumbnail/':
     get:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with Path.open(Path(this_directory, "README.md"), encoding="utf-8") as f:
 setup(
     name="carbonio-preview-ce",
     packages=find_packages(),
-    version="0.6.4",
+    version="0.6.5",
     entry_points={"console_scripts": ["controller = controller:main"]},
     description="Carbonio Preview.",
     long_description=Path.open(Path("README.md")).read(),


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com

SPDX-License-Identifier: AGPL-3.0-only
-->

# Description

carbonio.target should restart the services not covered by zmcontrol
Refs: [IN-881](https://zextras.atlassian.net/browse/IN-881)

## Type of change

Please delete options that are not relevant or put an 'x' on the desired options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
# Checklist:

This checklist is used as a reminder to avoid half-baked code
- [x] The PR title follows the following structure:" type[optional scope]: PREV-XX - LONG DESCRIPTION "
- [x] I have bumped both the PKGBUILD version and controller version, and they are the same.
- [] I have correctly installed and enabled pre-commit
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [] I have commented my code in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [] If I have introduced new dependencies I have added them to the pre-commit unittest additional_dependencies AND to the THIRDPARTIES file

[IN-881]: https://zextras.atlassian.net/browse/IN-881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ