### PR TITLE
chore: migrate Jenkinsfile to jenkins-lib-common@1.1.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,11 +12,11 @@ library(
 )
 
 library(
-    identifier: 'jenkins-packages-build-library@1.0.4',
+    identifier: 'jenkins-lib-common@1.1.2',
     retriever: modernSCM([
         $class: 'GitSCMSource',
-        remote: 'git@github.com:zextras/jenkins-packages-build-library.git',
-        credentialsId: 'jenkins-integration-with-github-account'
+        credentialsId: 'jenkins-integration-with-github-account',
+        remote: 'git@github.com:zextras/jenkins-lib-common.git'
     ])
 )
 
@@ -38,26 +38,13 @@ pipeline {
         timeout(time: 2, unit: 'HOURS')
     }
 
-    parameters {
-        booleanParam defaultValue: false,
-            description: 'Whether to upload the packages in playground repositories',
-            name: 'PLAYGROUND'
-        booleanParam(
-            name: 'PREPARE_RELEASE',
-            defaultValue: false,
-            description: 'Check this to prepare a new release (creates pre-release branch and PR)'
-        )
-    }
-
-    tools {
-        jfrog 'jfrog-cli'
-    }
-
     stages {
-        stage('Checkout') {
+        stage('Setup') {
             steps {
+                checkout scm
                 script {
-                    checkoutWithMetadata()
+                    gitMetadata()
+                    properties(defaultPipelineProperties())
                 }
             }
         }
@@ -80,9 +67,15 @@ pipeline {
         }
 
         stage('Upload artifacts') {
+            when {
+                expression { return uploadStage.shouldUpload() }
+            }
+            tools {
+                jfrog 'jfrog-cli'
+            }
             steps {
                 uploadStage(
-                    packages: yapHelper.getPackageNames('package/yap.json')
+                    packages: yapHelper.resolvePackageNames('package/yap.json')
                 )
             }
         }
@@ -133,19 +126,16 @@ pipeline {
             }
         }
 
-        stage('Build and Publish Docker Image') {
-            when {
-                not {
-                    expression { env.BRANCH_NAME.startsWith('PR-') }
-                }
-            }
+        stage('Publish docker images') {
             steps {
-                buildAndPublishDockerImage(
-                    projectName: 'carbonio-preview-ce',
+                dockerStage([
                     dockerfile: 'docker/minimal/carbonio-preview/Dockerfile',
-                    imageTitle: 'Carbonio Preview CE',
-                    imageDescription: 'Carbonio Preview Community Edition'
-                )
+                    imageName: 'carbonio-preview-ce',
+                    ocLabels: [
+                        title: 'Carbonio Preview CE',
+                        description: 'Carbonio Preview Community Edition'
+                    ]
+                ])
             }
         }
     }


### PR DESCRIPTION
Migrates Jenkinsfile from deprecated `jenkins-packages-build-library@1.0.4` to `jenkins-lib-common@1.1.2`.

## Changes

- **Library migration**: Updated to `jenkins-lib-common@1.1.2` from `jenkins-packages-build-library@1.0.4`
- **Parameters cleanup**: Removed unused `PLAYGROUND` parameter
- **Setup stage enhancement**: Renamed `Checkout` → `Setup` and added `properties(defaultPipelineProperties())` call
- **Tool scoping**: Moved `jfrog` tool declaration from pipeline-level to `Upload artifacts` stage

```groovy
// Before: global tools declaration
pipeline {
    tools {
        jfrog 'jfrog-cli'
    }
}

// After: stage-scoped tool
stage('Upload artifacts') {
    tools {
        jfrog 'jfrog-cli'
    }
    steps { ... }
}
```

- **Docker stage**: Modernized to use `dockerStage()` function
- **Package helper update**: Updated `yapHelper.getPackageNames()` to `yapHelper.resolvePackageNames()`

Resolve: [IN-959](https://zextras.atlassian.net/browse/IN-959)

[IN-959]: https://zextras.atlassian.net/browse/IN-959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ