### PR TITLE
fix: restore buildPackages() to fix pkgrel on tag builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,6 +65,8 @@ pipeline {
                         pkgbuildPath: 'package/preview/PKGBUILD',
                         buildStageConfig: [
                             buildDirs: ['package'],
+                            addCarbonioRepos: true,
+                            carbonioRepoCredentialId: 'artifactory-jenkins-gradle-properties-splitted',
                             preStashScript: '''
                                 tar czf package/preview/carbonio-preview-src.tar.gz \
                                     app package requirements.txt README.md setup.py

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,18 +60,18 @@ pipeline {
 
         stage('Build deb/rpm') {
             steps {
-                buildPackages([
-                    pkgbuildPath: 'package/preview/PKGBUILD',
-                    buildStageConfig: [
-                        buildDirs: ['package'],
-                        addCarbonioRepos: true,
-                        carbonioRepoCredentialId: 'artifactory-jenkins-gradle-properties-splitted',
-                        preStashScript: '''
-                            tar czf package/preview/carbonio-preview-src.tar.gz \
-                                app package requirements.txt README.md setup.py
-                        '''
-                    ]
-                ])
+                script {
+                    buildPackages([
+                        pkgbuildPath: 'package/preview/PKGBUILD',
+                        buildStageConfig: [
+                            buildDirs: ['package'],
+                            preStashScript: '''
+                                tar czf package/preview/carbonio-preview-src.tar.gz \
+                                    app package requirements.txt README.md setup.py
+                            '''
+                        ]
+                    ])
+                }
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,14 +60,17 @@ pipeline {
 
         stage('Build deb/rpm') {
             steps {
-                buildStage([
-                    buildDirs: ['package'],
-                    addCarbonioRepos: true,
-                    carbonioRepoCredentialId: 'artifactory-jenkins-gradle-properties-splitted',
-                    preStashScript: '''
-                        tar czf package/preview/carbonio-preview-src.tar.gz \
-                            app package requirements.txt README.md setup.py
-                    '''
+                buildPackages([
+                    pkgbuildPath: 'package/preview/PKGBUILD',
+                    buildStageConfig: [
+                        buildDirs: ['package'],
+                        addCarbonioRepos: true,
+                        carbonioRepoCredentialId: 'artifactory-jenkins-gradle-properties-splitted',
+                        preStashScript: '''
+                            tar czf package/preview/carbonio-preview-src.tar.gz \
+                                app package requirements.txt README.md setup.py
+                        '''
+                    ]
                 ])
             }
         }


### PR DESCRIPTION
## Summary
- Restores `buildPackages()` wrapper that was removed in CO-3422 batch commit (Apr 8)
- `buildStage()` alone does not call `updatePkgbuildRelease()`, causing SNAPSHOT pkgrel to leak into RC artifacts on tag builds
- `buildPackages()` calls `updatePkgbuildRelease()` → `buildStage()` → git checkout, ensuring pkgrel=1 on releases
- Explicit `pkgbuildPath: 'package/preview/PKGBUILD'` since this repo has a non-standard PKGBUILD location

## Test plan
- [ ] Verify devel branch build still produces SNAPSHOT packages
- [ ] Verify tag build produces pkgrel=1 packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)