### PR TITLE
feat(packaging): use arch=('any') for architecture-independent package

### DIFF
--- a/package/preview/PKGBUILD
+++ b/package/preview/PKGBUILD
@@ -10,7 +10,7 @@ license=("AGPL-3.0-only")
 url="https://github.com/zextras"
 section="admin"
 priority="optional"
-arch=('x86_64')
+arch=('any')
 
 depends__apt=(
   "pending-setups"


### PR DESCRIPTION
## Summary

- Replace `arch=('x86_64')` with `arch=('any')` in PKGBUILD since this package does not contain architecture-specific binaries

IN-951