### PR TITLE
chore(deps): update jenkins-lib-common to v2.8.7

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ library(
 )
 
 library(
-    identifier: 'jenkins-lib-common@v2.8.6',
+    identifier: 'jenkins-lib-common@v2.8.7',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ library(
 )
 
 library(
-    identifier: 'jenkins-lib-common@1.7.5',
+    identifier: 'jenkins-lib-common@v2.8.6',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,9 +84,7 @@ pipeline {
                 jfrog 'jfrog-cli'
             }
             steps {
-                uploadStage(
-                    packages: yapHelper.resolvePackageNames('package/yap.json')
-                )
+                uploadStage(yapPath: 'package/yap.json')
             }
         }
 


### PR DESCRIPTION
## Description

Upgrade `jenkins-lib-common` from `1.7.5` to `v2.8.7`.

### Changes applied

- Updated library version reference to `v2.8.7`
- Migrated `uploadStage(packages: yapHelper.resolvePackageNames('package/yap.json'))` to the new API (`uploadStage(yapPath: 'package/yap.json')`)
  (packages parameter was removed in v2.8.0 — the library now resolves
  package metadata internally from PKGBUILD files)
- Removed redundant `devel*`/`release*` branch guards superseded by v2.0.0
  trunk-based detection: N/A — the `branch 'devel'` guards in `Prepare Release` and `Tag for release` stages serve repo-specific logic, not upload/deploy gating, so they were kept

### Breaking changes in this upgrade

| Version | Change | Action Taken |
|---------|--------|--------------|
| v2.0.0 | Trunk-based branch guards replace `devel*`/`release*` | N/A — existing `branch 'devel'` guards serve repo-specific release logic, not upload gating |
| v2.8.0 | `uploadStage(packages:)` removed, hard-errors at runtime | Removed `packages:` arg and orphaned `yapHelper.resolvePackageNames()` call; replaced with `yapPath: 'package/yap.json'` |

### Verification

- [x] Jenkinsfile syntax is valid
- [x] No `packages:` arg in `uploadStage()` calls
- [x] No orphaned `yapHelper.getPackageNames()` / `resolvePackageNames()` calls
- [ ] PR build passes

## Type of change

- [x] Chore / CI (`chore:` / `ci:` / `test:` → no release)

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Branch is rebased on latest default branch with a linear history

## Notes for reviewers

Automated lib-common upgrade. Please verify the Upload stage runs correctly on
the PR build.