### PR TITLE
feat(ci): [IN-951] add arm64 platform to docker image builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -142,7 +142,8 @@ pipeline {
                     ocLabels: [
                         title: 'Carbonio Preview CE',
                         description: 'Carbonio Preview Community Edition'
-                    ]
+                    ],
+                    platforms: ['linux/amd64', 'linux/arm64'] as Set,
                 ])
             }
         }

--- a/docker/minimal/carbonio-preview/Dockerfile
+++ b/docker/minimal/carbonio-preview/Dockerfile
@@ -1,21 +1,80 @@
-FROM python:3.10-slim
+# syntax=docker/dockerfile:1.4
 
-RUN mkdir -p /etc/carbonio/preview
+# Stage 1: runs natively on BUILDPLATFORM (amd64 CI builder) — no QEMU.
+# Cross-fetches the Python wheels and the libcairo2 runtime closure for
+# TARGETARCH, then stages them so the final image needs zero RUN steps.
+FROM --platform=$BUILDPLATFORM python:3.10-slim AS builder
 
-RUN apt-get update && apt-get install -y \
-    libcairo2 \
-    && rm -rf /var/lib/apt/lists/*
+ARG TARGETARCH
+ARG BUILDARCH=amd64
 
-COPY app ./app
+WORKDIR /build
+
 COPY requirements.txt /tmp/requirements.txt
-COPY package/preview/messages.ini /etc/carbonio/preview/messages.ini
 
-RUN pip install --no-cache-dir -r /tmp/requirements.txt
+# Cross-install Python deps for the target arch into a staging tree.
+# Wheels are only unpacked (no target code runs), so this is QEMU-free.
+# Map Docker's TARGETARCH (amd64/arm64) to the manylinux wheel arch tag
+# (x86_64/aarch64). Pure-python wheels are picked up via the implicit
+# 'any' platform that pip always considers alongside --platform.
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+        amd64) WHEELARCH=x86_64 ;; \
+        arm64) WHEELARCH=aarch64 ;; \
+        *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    pip install --no-cache-dir --no-compile \
+        --target=/staging/opt/zextras/preview/site-packages \
+        --platform manylinux2014_${WHEELARCH} \
+        --platform manylinux_2_17_${WHEELARCH} \
+        --platform manylinux_2_28_${WHEELARCH} \
+        --python-version 310 --implementation cp --abi cp310 \
+        --only-binary=:all: \
+        -r /tmp/requirements.txt
 
-# Create log directory
-RUN mkdir -p /var/log/carbonio/preview/
+# Cross-fetch libcairo2 + its runtime .so closure for the target arch using
+# apt-get download + dpkg -x (no postinst, no target execution).
+RUN set -eux; \
+    if [ "${TARGETARCH}" != "${BUILDARCH}" ]; then \
+        dpkg --add-architecture ${TARGETARCH}; \
+    fi; \
+    apt-get update; \
+    mkdir -p /tmp/debs /staging/usr/local/lib; \
+    cd /tmp/debs; \
+    apt-get download \
+        libcairo2:${TARGETARCH} \
+        libpixman-1-0:${TARGETARCH} \
+        libfontconfig1:${TARGETARCH} \
+        libfreetype6:${TARGETARCH} \
+        libpng16-16t64:${TARGETARCH} \
+        libxcb-render0:${TARGETARCH} \
+        libxcb-shm0:${TARGETARCH} \
+        libxcb1:${TARGETARCH} \
+        libxext6:${TARGETARCH} \
+        libxrender1:${TARGETARCH} \
+        libx11-6:${TARGETARCH} \
+        libxau6:${TARGETARCH} \
+        libxdmcp6:${TARGETARCH} \
+        libbrotli1:${TARGETARCH} \
+        libexpat1:${TARGETARCH}; \
+    for deb in /tmp/debs/*.deb; do dpkg -x "$deb" /staging/cairo-root; done; \
+    find /staging/cairo-root -name '*.so*' -exec cp -Pv {} /staging/usr/local/lib/ \; ; \
+    rm -rf /tmp/debs /staging/cairo-root /var/lib/apt/lists/*
 
-ENV PYTHONPATH="/app:/opt/zextras/common/lib/python3.10/dist-packages:/opt/zextras/common/lib/python3.10/site-packages:/opt/zextras/common/lib64/python3.10/dist-packages:/opt/zextras/common/lib64/python3.10/site-packages:/opt/zextras/common/local/lib/python3.10/dist-packages:/opt/zextras/common/local/lib/python3.10/site-packages:/opt/zextras/common/local/lib64/python3.10/dist-packages:/opt/zextras/common/local/lib64/python3.10/site-packages:"
+COPY app /staging/opt/zextras/preview/app
+COPY package/preview/messages.ini /staging/etc/carbonio/preview/messages.ini
+
+# Stage 2: final image — TARGETPLATFORM, zero RUN steps (no QEMU needed).
+FROM --platform=$TARGETPLATFORM python:3.10-slim
+
+COPY --from=builder /staging/opt/zextras/preview /opt/zextras/preview
+COPY --from=builder /staging/etc/carbonio/preview /etc/carbonio/preview
+COPY --from=builder /staging/usr/local/lib /usr/local/lib
+
+ENV LD_LIBRARY_PATH="/usr/local/lib"
+ENV PYTHONPATH="/opt/zextras/preview/app:/opt/zextras/preview/site-packages:/opt/zextras/common/lib/python3.10/dist-packages:/opt/zextras/common/lib/python3.10/site-packages:/opt/zextras/common/lib64/python3.10/dist-packages:/opt/zextras/common/lib64/python3.10/site-packages:/opt/zextras/common/local/lib/python3.10/dist-packages:/opt/zextras/common/local/lib/python3.10/site-packages:/opt/zextras/common/local/lib64/python3.10/dist-packages:/opt/zextras/common/local/lib64/python3.10/site-packages:"
+
+WORKDIR /opt/zextras/preview
 
 CMD sh -c 'echo "# Carbonio Preview service configuration\n\
 [carbonio.preview]\n\
@@ -58,4 +117,5 @@ default_host = ${DOCS_EDITOR_HOST}\n\
 default_port = ${DOCS_EDITOR_PORT}\n\
 service_endpoint = services/docs/editor\n\
 convert_api = cool/convert-to" > /etc/carbonio/preview/config.ini && \
+mkdir -p /var/log/carbonio/preview/ && \
 python -m gunicorn app.controller:app --config app/gunicorn.conf.py'

--- a/package/yap.json
+++ b/package/yap.json
@@ -3,6 +3,7 @@
     "description": "Carbonio Preview sidecar",
     "buildDir": "/tmp/",
     "output": "artifacts",
+    "skipDeps": ["pending-setups", "service-discover", "service-discover-base"],
     "projects": [
         {
             "name": "preview"


### PR DESCRIPTION
Adds `platforms: ['linux/amd64', 'linux/arm64'] as Set` to each `dockerStage` call so images build for arm64 (Apple Silicon / MacOS) in addition to amd64.

Mirrors the merged carbonio-mailbox pattern (PR #994). The `as Set` cast is required: dockerHelper only emits `--platform` when platforms is a Set.

Ref: IN-951