### PR TITLE
build: migrate to buildah (FQDN images + jenkins-lib-common@2.10.0)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ library(
 )
 
 library(
-    identifier: 'jenkins-lib-common@v2.8.7',
+    identifier: 'jenkins-lib-common@v2.10.0',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',

--- a/docker/minimal/carbonio-docs-editor/Dockerfile
+++ b/docker/minimal/carbonio-docs-editor/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM docker.io/library/ubuntu:22.04
 
 USER root
 

--- a/docker/minimal/carbonio-preview/Dockerfile
+++ b/docker/minimal/carbonio-preview/Dockerfile
@@ -3,7 +3,7 @@
 # Stage 1: runs natively on BUILDPLATFORM (amd64 CI builder) — no QEMU.
 # Cross-fetches the Python wheels and the libcairo2 runtime closure for
 # TARGETARCH, then stages them so the final image needs zero RUN steps.
-FROM --platform=$BUILDPLATFORM python:3.10-slim AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/python:3.10-slim AS builder
 
 ARG TARGETARCH
 ARG BUILDARCH=amd64
@@ -65,7 +65,7 @@ COPY app /staging/opt/zextras/preview/app
 COPY package/preview/messages.ini /staging/etc/carbonio/preview/messages.ini
 
 # Stage 2: final image — TARGETPLATFORM, zero RUN steps (no QEMU needed).
-FROM --platform=$TARGETPLATFORM python:3.10-slim
+FROM --platform=$TARGETPLATFORM docker.io/library/python:3.10-slim
 
 COPY --from=builder /staging/opt/zextras/preview /opt/zextras/preview
 COPY --from=builder /staging/etc/carbonio/preview /etc/carbonio/preview

--- a/docker/minimal/carbonio-storages/Dockerfile
+++ b/docker/minimal/carbonio-storages/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM docker.io/library/node:18-alpine
 
 WORKDIR /app
 

--- a/docker/minimal/composed-ui/Dockerfile
+++ b/docker/minimal/composed-ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu/nginx:1.18-20.04_beta
+FROM docker.io/ubuntu/nginx:1.18-20.04_beta
 
 USER root
 

--- a/docker/packaging/Dockerfile
+++ b/docker/packaging/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-FROM alpine:3.23.2 AS prep
+FROM docker.io/library/alpine:3.23.2 AS prep
 WORKDIR /staging
 
 COPY ../../. .
@@ -45,7 +45,7 @@ COPY --from=prep /staging/staging .
 RUN yap build rocky-9 /tmp/staging/package
 
 # Final stage
-FROM alpine:3.23.2 AS final
+FROM docker.io/library/alpine:3.23.2 AS final
 WORKDIR /output
 
 COPY --from=ubuntu-focal-builder /tmp/staging/artifacts ./ubuntu-focal/


### PR DESCRIPTION
## Buildah migration

Replacing `docker buildx` with **buildah**, which requires fully-qualified image references.

### Changes
- **Dockerfiles:** fully-qualify base images (e.g. `alpine:3` -> `docker.io/library/alpine:3`). Multi-stage aliases and already-qualified refs untouched.
- **Jenkinsfile:** bump `jenkins-lib-common` to `@2.10.0`.

> Draft - part of org-wide buildah migration.