### PR TITLE
chore: [CO-3846] temporary revert to ProtectSystem=yes

### DIFF
--- a/package/preview/PKGBUILD
+++ b/package/preview/PKGBUILD
@@ -67,8 +67,8 @@ source=(
 sha256sums=(
   'f70942e22cffaa1b3783aece6275050cb70239573961c5c0cca30f83b5ba58ad'
   'cf5902414af144e4fde6c03f17308142596c65a8ec4f910e4cacfd93d863b0d9'
-  '4cfdd83b8a892eba82259989cc339bb3a311c671e753413cf24cf482f027160b'
-  '90e595d8cd5353f6a00ecfd56fd97cac7587894dfe97ac28ef5fec398b5901d9'
+  'c7713a8462f17e07378fa510492ec9886f26bea17acbc7b2b930fd2dc1f036ba'
+  '12d24f411c589801df931a7b3908fd5f6c702e9a14cd4fab2b8a1312e39ea3f3'
   'eaa158e0e71e93fd39b03750d1468dd9f8066891f9682209bde10547d36c1094'
   'cb294a1038886d60c4056a2b50ce8e49d923ad8d15226af4e742a7ae1f5523d6'
   'e98ceeb36ca3d9d1eb5afc799cdbe412c0fce1b99083864132288ff5b28dcb9c'
@@ -213,10 +213,10 @@ package__ubuntu_jammy() {
 }
 
 postinst() {
-  getent group 'carbonio-preview' >/dev/null \
-    || groupadd -r 'carbonio-preview'
-  getent passwd 'carbonio-preview' >/dev/null \
-    || useradd -r -m \
+  getent group 'carbonio-preview' >/dev/null ||
+    groupadd -r 'carbonio-preview'
+  getent passwd 'carbonio-preview' >/dev/null ||
+    useradd -r -m \
       -d '/var/lib/carbonio-preview' \
       -g 'carbonio-preview' \
       -s /sbin/nologin 'carbonio-preview'

--- a/package/preview/carbonio-preview-sidecar-legacy.service
+++ b/package/preview/carbonio-preview-sidecar-legacy.service
@@ -22,7 +22,11 @@ LimitNOFILE=65536
 
 # Hardening
 PrivateTmp=yes
-ProtectSystem=strict
+#ProtectSystem=strict
+ProtectSystem=yes
+ReadOnlyPaths=/usr
+ReadOnlyPaths=/boot
+ReadOnlyPaths=/efi
 NoNewPrivileges=yes
 PrivateDevices=yes
 ProtectHome=yes

--- a/package/preview/carbonio-preview-sidecar.service
+++ b/package/preview/carbonio-preview-sidecar.service
@@ -25,7 +25,11 @@ LimitNOFILE=65536
 
 # Hardening
 PrivateTmp=yes
-ProtectSystem=strict
+#ProtectSystem=strict
+ProtectSystem=yes
+ReadOnlyPaths=/usr
+ReadOnlyPaths=/boot
+ReadOnlyPaths=/efi
 NoNewPrivileges=yes
 PrivateDevices=yes
 ProtectHome=yes


### PR DESCRIPTION
## [CO-3846] Release systemd hardening with `ProtectSystem=yes` for 26.6

For 26.6, units with systemd hardening are released with `ProtectSystem=yes` instead of `ProtectSystem=strict`. The switch to `ProtectSystem=strict` as default is planned for 26.9.

### Change
- Comment out `ProtectSystem=strict` and its associated `ReadWritePaths=` entries.
- Set `ProtectSystem=yes`, keeping only `/usr`, `/boot` and `/efi` read-only via `ReadOnlyPaths`.
- Refresh PKGBUILD checksums where a modified `.service` is a local `source=()` entry.

### Why
With `strict` as default the behavior is correct on new installations, but it imposes a breaking change on upgrades: customers using non-standard paths (secondary volumes, local or NFS backups) would find those writes blocked after the upgrade. Releasing with `ProtectSystem=yes` improves the security baseline without breaking any existing installation on upgrade.

The step to `strict` returns in 26.9, giving partners a full release cycle to review their layouts and prepare overrides where needed. This is a choice of sequencing, not feature cancellation — `strict` remains the end state.

Follows the `carbonio-mailbox` CO-3846 pattern.


[CO-3846]: https://zextras.atlassian.net/browse/CO-3846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ