### PR TITLE
build: adopt Go /v2 module path + auto-sync /vN on future majors

### DIFF
--- a/.ci/set-go-major.sh
+++ b/.ci/set-go-major.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Keep the Go module's /vN major-version suffix in sync with the released major.
+#
+# Go's semantic import versioning requires a module at major version >= 2 to carry
+# a "/vN" suffix in its module path (and in every internal import). Otherwise a
+# consumer cannot `require github.com/.../carbonio-preview-ce/vN@vN.Y.Z` — it is
+# forced onto a commit pseudo-version. semantic-release computes the next version;
+# this script makes the module path follow it, so a `feat!:` that bumps the major
+# never silently leaves the path behind (no manual step to forget).
+#
+# Invoked from .releaserc.json prepareCmd:  bash .ci/set-go-major.sh <next-version>
+#
+# Fires ONLY when the major actually changes (no-op on minor/patch). Pure sed/grep,
+# so it needs no Go toolchain in the semantic-release pod.
+#
+# NOTE: this runs at release time, AFTER the CI build stages. The rewrite is a
+# deterministic, anchored sed (no import can be missed the way a hand-edit can),
+# but the exact /vN commit is only compiled by the *next* build. A follow-up
+# hardening is to do this rewrite pre-build in the pipeline, gated on a
+# semantic-release dry-run — see the PR discussion.
+set -euo pipefail
+
+next="${1:?usage: set-go-major.sh <next-version>}"
+new_major="${next%%.*}"
+
+base="github.com/zextras/carbonio-preview-ce"
+cur="$(awk '/^module /{print $2; exit}' go.mod)"
+
+# Desired module path: bare for v0/v1, "$base/vN" for N >= 2.
+if [ "${new_major}" -ge 2 ]; then
+  desired="${base}/v${new_major}"
+else
+  desired="${base}"
+fi
+
+if [ "${cur}" = "${desired}" ]; then
+  echo "[set-go-major] module path already '${desired}' (release ${next}) — nothing to do"
+  exit 0
+fi
+
+echo "[set-go-major] major changed for release ${next}: '${cur}' -> '${desired}'"
+
+# 1) go.mod module directive.
+sed -i "s#^module[[:space:]].*#module ${desired}#" go.mod
+
+# 2) internal imports. Anchor on a closing quote OR a trailing slash so we only
+#    touch this module's own import paths and never a longer, unrelated path
+#    (e.g. a hypothetical ...-rest-sdk) or a bare substring in a comment.
+grep -rlZ --include='*.go' "${cur}" . | while IFS= read -r -d '' f; do
+  sed -i \
+    -e "s#\"${cur}\"#\"${desired}\"#g" \
+    -e "s#${cur}/#${desired}/#g" \
+    "${f}"
+done
+
+echo "[set-go-major] rewrote module path + internal imports to '${desired}'"

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -39,13 +39,13 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "sed -i 's/^pkgver=.*/pkgver=\"${nextRelease.version}\"/' package/PKGBUILD && sed -i 's/^pkgrel=.*/pkgrel=\"1\"/' package/PKGBUILD"
+        "prepareCmd": "bash .ci/set-go-major.sh ${nextRelease.version} && sed -i 's/^pkgver=.*/pkgver=\"${nextRelease.version}\"/' package/PKGBUILD && sed -i 's/^pkgrel=.*/pkgrel=\"1\"/' package/PKGBUILD"
       }
     ],
     [
       "@semantic-release/git",
       {
-        "assets": ["CHANGELOG.md", "package/PKGBUILD"],
+        "assets": ["CHANGELOG.md", "package/PKGBUILD", "go.mod", "**/*.go"],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ]

--- a/cmd/carbonio-preview/main.go
+++ b/cmd/carbonio-preview/main.go
@@ -36,20 +36,20 @@ import (
 	"os"
 	"time"
 
-	"github.com/zextras/carbonio-preview-ce/cache"
-	"github.com/zextras/carbonio-preview-ce/config"
-	"github.com/zextras/carbonio-preview-ce/config/migrate"
+	"github.com/zextras/carbonio-preview-ce/v2/cache"
+	"github.com/zextras/carbonio-preview-ce/v2/config"
+	"github.com/zextras/carbonio-preview-ce/v2/config/migrate"
 	// Blank-imported so its init() registers the "ce" migration set into the
 	// config/migrate framework (RegisterInSet). Without this import, no CE
 	// migrations exist to run at --setup time — a plain import of
 	// config/migrate no longer carries them (that's the whole point: it lets
 	// the Advanced binary import config/migrate for the framework alone,
 	// without inheriting CE's migrations).
-	_ "github.com/zextras/carbonio-preview-ce/config/migrate/cemig"
-	"github.com/zextras/carbonio-preview-ce/docs"
-	"github.com/zextras/carbonio-preview-ce/render"
-	"github.com/zextras/carbonio-preview-ce/server"
-	"github.com/zextras/carbonio-preview-ce/storage"
+	_ "github.com/zextras/carbonio-preview-ce/v2/config/migrate/cemig"
+	"github.com/zextras/carbonio-preview-ce/v2/docs"
+	"github.com/zextras/carbonio-preview-ce/v2/render"
+	"github.com/zextras/carbonio-preview-ce/v2/server"
+	"github.com/zextras/carbonio-preview-ce/v2/storage"
 )
 
 func main() {

--- a/cmd/carbonio-preview/setup_test.go
+++ b/cmd/carbonio-preview/setup_test.go
@@ -13,13 +13,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/zextras/carbonio-preview-ce/config/migrate"
-	"github.com/zextras/carbonio-preview-ce/docs"
+	"github.com/zextras/carbonio-preview-ce/v2/config/migrate"
+	"github.com/zextras/carbonio-preview-ce/v2/docs"
 
 	// Blank-imported for the same reason main.go does: this test package
 	// exercises the --setup path end-to-end and must see CE's "ce" migration
 	// set registered, exactly like the production binary.
-	_ "github.com/zextras/carbonio-preview-ce/config/migrate/cemig"
+	_ "github.com/zextras/carbonio-preview-ce/v2/config/migrate/cemig"
 )
 
 // TestFindArg verifies the pure --setup flag locator.

--- a/cmd/configdocs/main.go
+++ b/cmd/configdocs/main.go
@@ -18,8 +18,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/zextras/carbonio-preview-ce/config"
-	"github.com/zextras/carbonio-preview-ce/configdocs"
+	"github.com/zextras/carbonio-preview-ce/v2/config"
+	"github.com/zextras/carbonio-preview-ce/v2/configdocs"
 )
 
 func main() {

--- a/cmd/gendocs/main.go
+++ b/cmd/gendocs/main.go
@@ -32,7 +32,7 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humago"
 
-	"github.com/zextras/carbonio-preview-ce/server/apispec"
+	"github.com/zextras/carbonio-preview-ce/v2/server/apispec"
 )
 
 func main() {

--- a/config/migrate/cemig/cemig_test.go
+++ b/config/migrate/cemig/cemig_test.go
@@ -15,7 +15,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/zextras/carbonio-preview-ce/config/migrate"
+	"github.com/zextras/carbonio-preview-ce/v2/config/migrate"
 )
 
 // ── helpers ───────────────────────────────────────────────────────────────────

--- a/config/migrate/cemig/v1.go
+++ b/config/migrate/cemig/v1.go
@@ -11,7 +11,7 @@
 // the framework but does NOT import this package — never inherits CE's V1.
 package cemig
 
-import "github.com/zextras/carbonio-preview-ce/config/migrate"
+import "github.com/zextras/carbonio-preview-ce/v2/config/migrate"
 
 func init() {
 	if err := migrate.RegisterInSet("ce", V1MigrateFromPythonIni()); err != nil {

--- a/configdocs/render_test.go
+++ b/configdocs/render_test.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/zextras/carbonio-preview-ce/config"
-	"github.com/zextras/carbonio-preview-ce/configdocs"
-	"github.com/zextras/carbonio-preview-ce/docs"
+	"github.com/zextras/carbonio-preview-ce/v2/config"
+	"github.com/zextras/carbonio-preview-ce/v2/configdocs"
+	"github.com/zextras/carbonio-preview-ce/v2/docs"
 )
 
 // ── Drift-guard tests ─────────────────────────────────────────────────────────

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-module github.com/zextras/carbonio-preview-ce
+module github.com/zextras/carbonio-preview-ce/v2
 
 go 1.25.0
 

--- a/server/api.go
+++ b/server/api.go
@@ -18,13 +18,13 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humago"
 
-	"github.com/zextras/carbonio-preview-ce/cache"
-	"github.com/zextras/carbonio-preview-ce/config"
-	"github.com/zextras/carbonio-preview-ce/db"
-	"github.com/zextras/carbonio-preview-ce/render"
-	"github.com/zextras/carbonio-preview-ce/server/apispec"
-	"github.com/zextras/carbonio-preview-ce/storage"
-	"github.com/zextras/carbonio-preview-ce/video"
+	"github.com/zextras/carbonio-preview-ce/v2/cache"
+	"github.com/zextras/carbonio-preview-ce/v2/config"
+	"github.com/zextras/carbonio-preview-ce/v2/db"
+	"github.com/zextras/carbonio-preview-ce/v2/render"
+	"github.com/zextras/carbonio-preview-ce/v2/server/apispec"
+	"github.com/zextras/carbonio-preview-ce/v2/storage"
+	"github.com/zextras/carbonio-preview-ce/v2/video"
 )
 
 // ---------------------------------------------------------------------------

--- a/server/api_generate_test.go
+++ b/server/api_generate_test.go
@@ -12,8 +12,8 @@ import (
 	"io"
 	"testing"
 
-	"github.com/zextras/carbonio-preview-ce/storage"
-	"github.com/zextras/carbonio-preview-ce/video"
+	"github.com/zextras/carbonio-preview-ce/v2/storage"
+	"github.com/zextras/carbonio-preview-ce/v2/video"
 )
 
 // genFakeStore records StoreData calls and serves a canned video stream. A

--- a/server/cache_integration_test.go
+++ b/server/cache_integration_test.go
@@ -10,7 +10,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/zextras/carbonio-preview-ce/cache"
+	"github.com/zextras/carbonio-preview-ce/v2/cache"
 )
 
 func newCacheTestServer(t *testing.T, store *mockStore, maxBytes int64) *http.ServeMux {

--- a/server/document_test.go
+++ b/server/document_test.go
@@ -14,9 +14,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/zextras/carbonio-preview-ce/config"
-	"github.com/zextras/carbonio-preview-ce/render"
-	"github.com/zextras/carbonio-preview-ce/storage"
+	"github.com/zextras/carbonio-preview-ce/v2/config"
+	"github.com/zextras/carbonio-preview-ce/v2/render"
+	"github.com/zextras/carbonio-preview-ce/v2/storage"
 )
 
 // stubCollaboraConvert replaces collaboraConvertFunc for the duration of a test.

--- a/server/fullflow_test.go
+++ b/server/fullflow_test.go
@@ -33,10 +33,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/zextras/carbonio-preview-ce/cache"
-	"github.com/zextras/carbonio-preview-ce/config"
-	"github.com/zextras/carbonio-preview-ce/server/testsupport"
-	"github.com/zextras/carbonio-preview-ce/storage"
+	"github.com/zextras/carbonio-preview-ce/v2/cache"
+	"github.com/zextras/carbonio-preview-ce/v2/config"
+	"github.com/zextras/carbonio-preview-ce/v2/server/testsupport"
+	"github.com/zextras/carbonio-preview-ce/v2/storage"
 )
 
 // fullFlowFixtures holds the real test bytes, loaded once.

--- a/server/health_test.go
+++ b/server/health_test.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/zextras/carbonio-preview-ce/config"
+	"github.com/zextras/carbonio-preview-ce/v2/config"
 )
 
 // buildHealthMux creates a huma-routed mux for health operations (test helper).

--- a/server/health_types.go
+++ b/server/health_types.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/zextras/carbonio-preview-ce/server/apispec"
+	"github.com/zextras/carbonio-preview-ce/v2/server/apispec"
 )
 
 // isDependencyUp performs a GET to url with a 5-second timeout.

--- a/server/image_test.go
+++ b/server/image_test.go
@@ -18,8 +18,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/zextras/carbonio-preview-ce/config"
-	"github.com/zextras/carbonio-preview-ce/storage"
+	"github.com/zextras/carbonio-preview-ce/v2/config"
+	"github.com/zextras/carbonio-preview-ce/v2/storage"
 )
 
 // ---- mock storage ----

--- a/server/params.go
+++ b/server/params.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/zextras/carbonio-preview-ce/config"
+	"github.com/zextras/carbonio-preview-ce/v2/config"
 )
 
 // areaRegex matches the {area} path segment: two non-negative integers

--- a/server/pdf_test.go
+++ b/server/pdf_test.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/zextras/carbonio-preview-ce/config"
-	"github.com/zextras/carbonio-preview-ce/render"
-	"github.com/zextras/carbonio-preview-ce/storage"
+	"github.com/zextras/carbonio-preview-ce/v2/config"
+	"github.com/zextras/carbonio-preview-ce/v2/render"
+	"github.com/zextras/carbonio-preview-ce/v2/storage"
 )
 
 // fakePDFBytes is a minimal stand-in for real PDF content.

--- a/server/register_shims.go
+++ b/server/register_shims.go
@@ -12,7 +12,7 @@ package server
 import (
 	"github.com/danielgtaylor/huma/v2"
 
-	"github.com/zextras/carbonio-preview-ce/server/apispec"
+	"github.com/zextras/carbonio-preview-ce/v2/server/apispec"
 )
 
 func registerImageOps(api huma.API, deps Deps) {

--- a/server/render_hooks.go
+++ b/server/render_hooks.go
@@ -19,8 +19,8 @@ import (
 	"io"
 	"time"
 
-	"github.com/zextras/carbonio-preview-ce/render"
-	"github.com/zextras/carbonio-preview-ce/video"
+	"github.com/zextras/carbonio-preview-ce/v2/render"
+	"github.com/zextras/carbonio-preview-ce/v2/video"
 )
 
 // imageThumbnailFunc is the seam for render.ImageThumbnail.

--- a/server/render_slot_test.go
+++ b/server/render_slot_test.go
@@ -13,9 +13,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/zextras/carbonio-preview-ce/cache"
-	"github.com/zextras/carbonio-preview-ce/config"
-	"github.com/zextras/carbonio-preview-ce/storage"
+	"github.com/zextras/carbonio-preview-ce/v2/cache"
+	"github.com/zextras/carbonio-preview-ce/v2/config"
+	"github.com/zextras/carbonio-preview-ce/v2/storage"
 )
 
 // slotTestStore returns canned bytes so the handler reaches the render step.

--- a/server/server.go
+++ b/server/server.go
@@ -16,11 +16,11 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/zextras/carbonio-preview-ce/cache"
-	"github.com/zextras/carbonio-preview-ce/config"
-	"github.com/zextras/carbonio-preview-ce/db"
-	"github.com/zextras/carbonio-preview-ce/render"
-	"github.com/zextras/carbonio-preview-ce/storage"
+	"github.com/zextras/carbonio-preview-ce/v2/cache"
+	"github.com/zextras/carbonio-preview-ce/v2/config"
+	"github.com/zextras/carbonio-preview-ce/v2/db"
+	"github.com/zextras/carbonio-preview-ce/v2/render"
+	"github.com/zextras/carbonio-preview-ce/v2/storage"
 )
 
 // Server is the top-level HTTP server. Create it with New and start it with Run.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -10,7 +10,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/zextras/carbonio-preview-ce/cache"
+	"github.com/zextras/carbonio-preview-ce/v2/cache"
 )
 
 // Run is intentionally NOT unit-tested here: it calls render.InitVips, requires

--- a/server/testsupport/render_bootstrap.go
+++ b/server/testsupport/render_bootstrap.go
@@ -13,7 +13,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/zextras/carbonio-preview-ce/render"
+	"github.com/zextras/carbonio-preview-ce/v2/render"
 )
 
 // InitRealRender builds the pdfium worker from source, initialises the libvips

--- a/server/video_api.go
+++ b/server/video_api.go
@@ -22,11 +22,11 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/google/uuid"
 
-	"github.com/zextras/carbonio-preview-ce/cache"
-	"github.com/zextras/carbonio-preview-ce/config"
-	"github.com/zextras/carbonio-preview-ce/db"
-	"github.com/zextras/carbonio-preview-ce/server/apispec"
-	"github.com/zextras/carbonio-preview-ce/storage"
+	"github.com/zextras/carbonio-preview-ce/v2/cache"
+	"github.com/zextras/carbonio-preview-ce/v2/config"
+	"github.com/zextras/carbonio-preview-ce/v2/db"
+	"github.com/zextras/carbonio-preview-ce/v2/server/apispec"
+	"github.com/zextras/carbonio-preview-ce/v2/storage"
 )
 
 // ---------------------------------------------------------------------------

--- a/server/video_api_test.go
+++ b/server/video_api_test.go
@@ -30,11 +30,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/zextras/carbonio-preview-ce/cache"
-	"github.com/zextras/carbonio-preview-ce/db"
-	"github.com/zextras/carbonio-preview-ce/server/apispec"
-	"github.com/zextras/carbonio-preview-ce/storage"
-	"github.com/zextras/carbonio-preview-ce/video"
+	"github.com/zextras/carbonio-preview-ce/v2/cache"
+	"github.com/zextras/carbonio-preview-ce/v2/db"
+	"github.com/zextras/carbonio-preview-ce/v2/server/apispec"
+	"github.com/zextras/carbonio-preview-ce/v2/storage"
+	"github.com/zextras/carbonio-preview-ce/v2/video"
 )
 
 // ---------------------------------------------------------------------------

--- a/server/video_codec_test.go
+++ b/server/video_codec_test.go
@@ -18,8 +18,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/zextras/carbonio-preview-ce/db"
-	"github.com/zextras/carbonio-preview-ce/video"
+	"github.com/zextras/carbonio-preview-ce/v2/db"
+	"github.com/zextras/carbonio-preview-ce/v2/video"
 )
 
 // ---------------------------------------------------------------------------

--- a/server/video_codecs.go
+++ b/server/video_codecs.go
@@ -9,7 +9,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/zextras/carbonio-preview-ce/video"
+	"github.com/zextras/carbonio-preview-ce/v2/video"
 )
 
 // supportedVideoCodecs is the hardcoded set of codecs that carbonio-ffmpeg can

--- a/server/video_gate.go
+++ b/server/video_gate.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"sync/atomic"
 
-	"github.com/zextras/carbonio-preview-ce/db"
+	"github.com/zextras/carbonio-preview-ce/v2/db"
 )
 
 // videoGate holds the video-preview DB store behind an atomic pointer so the

--- a/server/video_gate_test.go
+++ b/server/video_gate_test.go
@@ -24,9 +24,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/zextras/carbonio-preview-ce/cache"
-	"github.com/zextras/carbonio-preview-ce/db"
-	"github.com/zextras/carbonio-preview-ce/server/apispec"
+	"github.com/zextras/carbonio-preview-ce/v2/cache"
+	"github.com/zextras/carbonio-preview-ce/v2/db"
+	"github.com/zextras/carbonio-preview-ce/v2/server/apispec"
 )
 
 // statusOf extracts the HTTP status carried by a huma error.

--- a/server/video_worker.go
+++ b/server/video_worker.go
@@ -34,9 +34,9 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/zextras/carbonio-preview-ce/db"
-	"github.com/zextras/carbonio-preview-ce/storage"
-	"github.com/zextras/carbonio-preview-ce/video"
+	"github.com/zextras/carbonio-preview-ce/v2/db"
+	"github.com/zextras/carbonio-preview-ce/v2/storage"
+	"github.com/zextras/carbonio-preview-ce/v2/video"
 )
 
 // readIdleTimeout is the maximum silence between successive bytes on the source

--- a/server/video_worker_test.go
+++ b/server/video_worker_test.go
@@ -29,9 +29,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/zextras/carbonio-preview-ce/cache"
-	"github.com/zextras/carbonio-preview-ce/db"
-	"github.com/zextras/carbonio-preview-ce/storage"
+	"github.com/zextras/carbonio-preview-ce/v2/cache"
+	"github.com/zextras/carbonio-preview-ce/v2/db"
+	"github.com/zextras/carbonio-preview-ce/v2/storage"
 )
 
 // ---------------------------------------------------------------------------

--- a/server/videodb_start.go
+++ b/server/videodb_start.go
@@ -23,8 +23,8 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/zextras/carbonio-preview-ce/config"
-	"github.com/zextras/carbonio-preview-ce/db"
+	"github.com/zextras/carbonio-preview-ce/v2/config"
+	"github.com/zextras/carbonio-preview-ce/v2/db"
 )
 
 const (

--- a/server/videodb_start_test.go
+++ b/server/videodb_start_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/zextras/carbonio-preview-ce/cache"
+	"github.com/zextras/carbonio-preview-ce/v2/cache"
 )
 
 // startVideoPostgresDSN spins up a throwaway Postgres 16 container (mirroring


### PR DESCRIPTION
## What
Two things, so a Go consumer can pin `carbonio-preview-ce` at a **clean semver** (`require .../carbonio-preview-ce/v2@v2.x.y`) instead of a commit pseudo-version, and so this **never has to be remembered by hand** on future major bumps.

**1. `build:` — adopt the `/v2` module path now (manual, one-time).**
CE is at product major 2 (the go rewrite). Go's semantic import versioning requires the module path to carry the major suffix for v2+. Set `module github.com/zextras/carbonio-preview-ce/v2` and rewrite all 33 internal imports. Verified locally: `go build ./...` (cgo, libvips+pdfium) + `go vet` pass.

**2. `ci:` — auto-manage `/vN` on future majors via semantic-release.**
`.ci/set-go-major.sh <next-version>` is invoked from `.releaserc.json` `prepareCmd`. On a MAJOR bump (v2→v3…) it rewrites the go.mod module directive + every internal import to the new `/vN`; **no-op on minor/patch**. The rewritten `go.mod` + `**/*.go` are added to the `@semantic-release/git` assets so they land in the tagged release commit. Pure sed/grep (no Go toolchain needed in the release pod), anchored on quote/slash so it never touches unrelated paths (e.g. `-rest-sdk`). Tested: no-op for `2.0.1`; `3.0.0` → rewrites `/v2`→`/v3` and `go build ./...` still passes.

## Expected release
This should cut a **2.x patch** (both commits are `build:`/`ci:` → patch), NOT a major — so `/v2` stays valid and the tag it produces (e.g. `v2.0.1`) is the first `/v2`-correct tag. Consumers then pin `.../carbonio-preview-ce/v2@v2.0.1`.

## Consumers (manual, as agreed)
Advanced (`carbonio-preview`) must bump its imports to `/v2` and `require .../carbonio-preview-ce/v2@<this tag>` + `go mod tidy`. That cross-repo bump is done by hand (a CE release cannot touch another repo).

## Known tradeoff
The auto-rewrite (part 2) runs at release time, **after** CI, so the exact `/vN` commit is first compiled by the *next* build. The rewrite is a deterministic anchored sed (can't silently miss an import the way a hand-edit can), but a fully-safe variant would do the rewrite pre-build in the dt3 pipeline gated on a semantic-release dry-run — noted as a possible follow-up.