### PR TITLE
refactor(config): rename 4 Consul-KV keys into clearer namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,14 +89,14 @@ for the authoritative list of keys and defaults.
 
 | Consul KV key | Env override | Default | Description |
 |---------------|--------------|---------|-------------|
-| `carbonio-preview/render/max-concurrent-operations` | `APPLICATION_CONFIG_RENDER_MAX_CONCURRENT_OPERATIONS` | *CPU count* | Max concurrent render operations (image, PDF, document); does not apply to video |
-| `carbonio-preview/render/pdf-subprocess-pool-size` | `APPLICATION_CONFIG_RENDER_PDF_SUBPROCESS_POOL_SIZE` | *CPU count* | Number of PDFium helper OS subprocesses |
-| `carbonio-preview/render/cache-max-mb` | `APPLICATION_CONFIG_RENDER_CACHE_MAX_MB` | `256` | Size budget (MiB) of the shared rendered-output cache; `0` disables it |
+| `carbonio-preview/image-document/max-concurrent-operations` | `APPLICATION_CONFIG_IMAGE_DOCUMENT_MAX_CONCURRENT_OPERATIONS` | *CPU count* | Max concurrent render operations (image, PDF, document); does not apply to video |
+| `carbonio-preview/document/subprocess-pool-size` | `APPLICATION_CONFIG_DOCUMENT_SUBPROCESS_POOL_SIZE` | *CPU count* | Number of PDFium helper OS subprocesses |
+| `carbonio-preview/cache-max-mb` | `APPLICATION_CONFIG_CACHE_MAX_MB` | `256` | Size budget (MiB) of the global rendered-output cache shared by all preview types (image, PDF, document, video); `0` disables it |
 | `carbonio-preview/video/max-concurrent-extractions` | `APPLICATION_CONFIG_VIDEO_MAX_CONCURRENT_EXTRACTIONS` | *CPU count* | Max concurrent video first-frame extraction jobs |
-| `carbonio-preview/storage/fetch-timeout-seconds` | `APPLICATION_CONFIG_STORAGE_FETCH_TIMEOUT_SECONDS` | `30` | Timeout (s) for fetching the source blob from carbonio-storages |
+| `carbonio-preview/image-document/fetch-timeout-seconds` | `APPLICATION_CONFIG_IMAGE_DOCUMENT_FETCH_TIMEOUT_SECONDS` | `30` | Timeout (s) for fetching the source blob from carbonio-storages |
 | `carbonio-preview/document/conversion-timeout-seconds` | `APPLICATION_CONFIG_DOCUMENT_CONVERSION_TIMEOUT_SECONDS` | `15` | Timeout (s) for carbonio-docs-editor (Collabora) conversion |
 
-Values must be positive integers >= 1 (`render/cache-max-mb` also accepts `0` to disable
+Values must be positive integers >= 1 (`cache-max-mb` also accepts `0` to disable
 the cache). An invalid value causes the service to fail-fast at startup.
 
 A few knobs are true per-instance environment variables, set via systemd drop-in

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -65,7 +65,7 @@ type Cache struct {
 	mu     sync.Mutex
 	m      map[string]*item
 	used   int64 // sum of len(body) over all items
-	budget int64 // byte budget (render.cache-max-mb × 1024×1024)
+	budget int64 // byte budget (cache-max-mb × 1024×1024)
 }
 
 // New builds a Cache with the given byte budget. A budget <= 0 disables caching:

--- a/config/config.go
+++ b/config/config.go
@@ -58,16 +58,16 @@ type Config struct {
 
 	// RenderConcurrency is the maximum number of concurrent render operations
 	// (image, PDF, document; does not apply to video).
-	// Application-layer key "render.max-concurrent-operations" (Consul KV
-	// carbonio-preview/render/max-concurrent-operations / env
-	// APPLICATION_CONFIG_RENDER_MAX_CONCURRENT_OPERATIONS). Defaults to
+	// Application-layer key "image-document.max-concurrent-operations" (Consul KV
+	// carbonio-preview/image-document/max-concurrent-operations / env
+	// APPLICATION_CONFIG_IMAGE_DOCUMENT_MAX_CONCURRENT_OPERATIONS). Defaults to
 	// runtime.NumCPU() when absent.
 	RenderConcurrency int
 
 	// PDFWorkers is the size of the PDFium subprocess worker pool.
-	// Application-layer key "render.pdf-subprocess-pool-size" (Consul KV
-	// carbonio-preview/render/pdf-subprocess-pool-size / env
-	// APPLICATION_CONFIG_RENDER_PDF_SUBPROCESS_POOL_SIZE). Defaults to
+	// Application-layer key "document.subprocess-pool-size" (Consul KV
+	// carbonio-preview/document/subprocess-pool-size / env
+	// APPLICATION_CONFIG_DOCUMENT_SUBPROCESS_POOL_SIZE). Defaults to
 	// runtime.NumCPU() when absent.
 	PDFWorkers int
 
@@ -84,9 +84,9 @@ type Config struct {
 	VIPSConcurrency int
 
 	// CacheMaxBytes is the byte budget of the in-process rendered-output cache,
-	// derived from the "render.cache-max-mb" application key (MiB → bytes). 0
+	// derived from the "cache-max-mb" application key (MiB → bytes). 0
 	// disables the cache. Application key ⇒ env override
-	// APPLICATION_CONFIG_RENDER_CACHE_MAX_MB is accepted automatically by the
+	// APPLICATION_CONFIG_CACHE_MAX_MB is accepted automatically by the
 	// resolver chain.
 	CacheMaxBytes int64
 
@@ -219,17 +219,17 @@ func Load() error {
 
 	c.ServiceEnableDocumentPreview, parseErr = appBool(r, "document.enable-preview", parseErr)
 	c.ServiceEnableDocumentThumbnail, parseErr = appBool(r, "document.enable-thumbnail", parseErr)
-	c.ServiceTimeoutInSeconds, parseErr = appPositiveInt(r, "storage.fetch-timeout-seconds", parseErr)
+	c.ServiceTimeoutInSeconds, parseErr = appPositiveInt(r, "image-document.fetch-timeout-seconds", parseErr)
 	c.ServiceDocsTimeout, parseErr = appPositiveInt(r, "document.conversion-timeout-seconds", parseErr)
 
 	var cacheMaxMB int
-	cacheMaxMB, parseErr = appNonNegativeInt(r, "render.cache-max-mb", parseErr)
+	cacheMaxMB, parseErr = appNonNegativeInt(r, "cache-max-mb", parseErr)
 
 	// Concurrency knobs (APPLICATION layer). Absent → 0 here → runtime.NumCPU()
 	// fallback below. A present-but-invalid value (non-integer or < 1) fails fast
 	// via appPositiveInt.
-	c.RenderConcurrency, parseErr = appPositiveInt(r, "render.max-concurrent-operations", parseErr)
-	c.PDFWorkers, parseErr = appPositiveInt(r, "render.pdf-subprocess-pool-size", parseErr)
+	c.RenderConcurrency, parseErr = appPositiveInt(r, "image-document.max-concurrent-operations", parseErr)
+	c.PDFWorkers, parseErr = appPositiveInt(r, "document.subprocess-pool-size", parseErr)
 	c.VideoConcurrency, parseErr = appPositiveInt(r, "video.max-concurrent-extractions", parseErr)
 
 	var dbPoolMaxConns, dbPoolMinConns, dbConnMaxLifetimeMs int

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -121,7 +121,7 @@ func TestDefaults(t *testing.T) {
 	}
 }
 
-// TestPDFWorkersFallbackToCPUCount verifies that when render.pdf-subprocess-pool-size
+// TestPDFWorkersFallbackToCPUCount verifies that when document.subprocess-pool-size
 // is absent from all sources, PDFWorkers is set to runtime.NumCPU().
 func TestPDFWorkersFallbackToCPUCount(t *testing.T) {
 	srv := buildKVServer(t, nil)
@@ -136,8 +136,8 @@ func TestPDFWorkersFallbackToCPUCount(t *testing.T) {
 // TestConfig_ConcurrencyFromApplicationEnv verifies that the three concurrency
 // knobs resolve from the APPLICATION_CONFIG_* env layer (the migrated chain).
 func TestConfig_ConcurrencyFromApplicationEnv(t *testing.T) {
-	t.Setenv("APPLICATION_CONFIG_RENDER_MAX_CONCURRENT_OPERATIONS", "4")
-	t.Setenv("APPLICATION_CONFIG_RENDER_PDF_SUBPROCESS_POOL_SIZE", "2")
+	t.Setenv("APPLICATION_CONFIG_IMAGE_DOCUMENT_MAX_CONCURRENT_OPERATIONS", "4")
+	t.Setenv("APPLICATION_CONFIG_DOCUMENT_SUBPROCESS_POOL_SIZE", "2")
 	t.Setenv("APPLICATION_CONFIG_VIDEO_MAX_CONCURRENT_EXTRACTIONS", "3")
 	srv := buildKVServer(t, nil)
 	if err := loadWithConsul(t, srv); err != nil {
@@ -158,9 +158,9 @@ func TestConfig_ConcurrencyFromApplicationEnv(t *testing.T) {
 // from Consul KV (carbonio-preview/<key>).
 func TestConfig_ConcurrencyFromKV(t *testing.T) {
 	srv := buildKVServer(t, map[string]string{
-		"render/max-concurrent-operations": "6",
-		"render/pdf-subprocess-pool-size":  "7",
-		"video/max-concurrent-extractions": "8",
+		"image-document/max-concurrent-operations": "6",
+		"document/subprocess-pool-size":            "7",
+		"video/max-concurrent-extractions":         "8",
 	})
 	if err := loadWithConsul(t, srv); err != nil {
 		t.Fatalf("Load(): %v", err)
@@ -286,11 +286,11 @@ func TestEnvOverridesDocsEditorHost(t *testing.T) {
 	}
 }
 
-// TestStoragesTimeoutKVOverride verifies that the "storage/fetch-timeout-seconds"
+// TestStoragesTimeoutKVOverride verifies that the "image-document/fetch-timeout-seconds"
 // Consul KV key overrides the default (30) and is reflected in ServiceTimeoutInSeconds.
 func TestStoragesTimeoutKVOverride(t *testing.T) {
 	srv := buildKVServer(t, map[string]string{
-		"storage/fetch-timeout-seconds": "60",
+		"image-document/fetch-timeout-seconds": "60",
 	})
 	if err := loadWithConsul(t, srv); err != nil {
 		t.Fatalf("Load(): %v", err)
@@ -449,19 +449,19 @@ func TestAreDocsEnabled(t *testing.T) {
 // ─── parse-failure → error ────────────────────────────────────────────────────
 
 // TestParseFailureKVTimeout verifies that a non-integer
-// "storage/fetch-timeout-seconds" Consul KV value causes Load() to return an
+// "image-document/fetch-timeout-seconds" Consul KV value causes Load() to return an
 // error naming the key.
 func TestParseFailureKVTimeout(t *testing.T) {
 	srv := buildKVServer(t, map[string]string{
-		"storage/fetch-timeout-seconds": "not-a-number",
+		"image-document/fetch-timeout-seconds": "not-a-number",
 	})
 	pointConsulAt(t, srv)
 	err := Load()
 	if err == nil {
-		t.Fatal("expected error for bad storage.fetch-timeout-seconds value, got nil")
+		t.Fatal("expected error for bad image-document.fetch-timeout-seconds value, got nil")
 	}
-	if !strings.Contains(err.Error(), "storage.fetch-timeout-seconds") {
-		t.Errorf("error %q should mention key %q", err.Error(), "storage.fetch-timeout-seconds")
+	if !strings.Contains(err.Error(), "image-document.fetch-timeout-seconds") {
+		t.Errorf("error %q should mention key %q", err.Error(), "image-document.fetch-timeout-seconds")
 	}
 }
 
@@ -482,17 +482,17 @@ func TestParseFailureBoolKey(t *testing.T) {
 	}
 }
 
-// TestParseFailurePDFWorkers verifies that a bad render/pdf-subprocess-pool-size
+// TestParseFailurePDFWorkers verifies that a bad document/subprocess-pool-size
 // KV value is an error naming the key.
 func TestParseFailurePDFWorkers(t *testing.T) {
-	srv := buildKVServer(t, map[string]string{"render/pdf-subprocess-pool-size": "banana"})
+	srv := buildKVServer(t, map[string]string{"document/subprocess-pool-size": "banana"})
 	pointConsulAt(t, srv)
 	err := Load()
 	if err == nil {
-		t.Fatal("expected error for bad render.pdf-subprocess-pool-size value, got nil")
+		t.Fatal("expected error for bad document.subprocess-pool-size value, got nil")
 	}
-	if !strings.Contains(err.Error(), "render.pdf-subprocess-pool-size") {
-		t.Errorf("error %q should mention key %q", err.Error(), "render.pdf-subprocess-pool-size")
+	if !strings.Contains(err.Error(), "document.subprocess-pool-size") {
+		t.Errorf("error %q should mention key %q", err.Error(), "document.subprocess-pool-size")
 	}
 }
 
@@ -500,7 +500,7 @@ func TestParseFailurePDFWorkers(t *testing.T) {
 // (not a positive integer) causes Load() to return an error naming the key.
 func TestParseFailureZeroKVTimeout(t *testing.T) {
 	for _, tc := range []struct{ kvPath, wantKey, name string }{
-		{"storage/fetch-timeout-seconds", "storage.fetch-timeout-seconds", "storages timeout"},
+		{"image-document/fetch-timeout-seconds", "image-document.fetch-timeout-seconds", "storages timeout"},
 		{"document/conversion-timeout-seconds", "document.conversion-timeout-seconds", "docs timeout"},
 	} {
 		tc := tc
@@ -521,30 +521,30 @@ func TestParseFailureZeroKVTimeout(t *testing.T) {
 }
 
 // TestParseFailureNegativeRenderConcurrency verifies that
-// render.max-concurrent-operations=-1 is rejected.
+// image-document.max-concurrent-operations=-1 is rejected.
 func TestParseFailureNegativeRenderConcurrency(t *testing.T) {
-	srv := buildKVServer(t, map[string]string{"render/max-concurrent-operations": "-1"})
+	srv := buildKVServer(t, map[string]string{"image-document/max-concurrent-operations": "-1"})
 	pointConsulAt(t, srv)
 	err := Load()
 	if err == nil {
-		t.Fatal("expected error for render.max-concurrent-operations=-1, got nil")
+		t.Fatal("expected error for image-document.max-concurrent-operations=-1, got nil")
 	}
-	if !strings.Contains(err.Error(), "render.max-concurrent-operations") {
-		t.Errorf("error %q should mention key %q", err.Error(), "render.max-concurrent-operations")
+	if !strings.Contains(err.Error(), "image-document.max-concurrent-operations") {
+		t.Errorf("error %q should mention key %q", err.Error(), "image-document.max-concurrent-operations")
 	}
 }
 
-// TestParseFailureZeroPDFWorkers verifies that render.pdf-subprocess-pool-size=0
+// TestParseFailureZeroPDFWorkers verifies that document.subprocess-pool-size=0
 // is rejected (appPositiveInt requires >= 1).
 func TestParseFailureZeroPDFWorkers(t *testing.T) {
-	srv := buildKVServer(t, map[string]string{"render/pdf-subprocess-pool-size": "0"})
+	srv := buildKVServer(t, map[string]string{"document/subprocess-pool-size": "0"})
 	pointConsulAt(t, srv)
 	err := Load()
 	if err == nil {
-		t.Fatal("expected error for render.pdf-subprocess-pool-size=0, got nil")
+		t.Fatal("expected error for document.subprocess-pool-size=0, got nil")
 	}
-	if !strings.Contains(err.Error(), "render.pdf-subprocess-pool-size") {
-		t.Errorf("error %q should mention key %q", err.Error(), "render.pdf-subprocess-pool-size")
+	if !strings.Contains(err.Error(), "document.subprocess-pool-size") {
+		t.Errorf("error %q should mention key %q", err.Error(), "document.subprocess-pool-size")
 	}
 }
 
@@ -704,7 +704,7 @@ func TestCacheMaxMBDefault(t *testing.T) {
 }
 
 func TestCacheMaxMBKVOverride(t *testing.T) {
-	srv := buildKVServer(t, map[string]string{"render/cache-max-mb": "512"})
+	srv := buildKVServer(t, map[string]string{"cache-max-mb": "512"})
 	if err := loadWithConsul(t, srv); err != nil {
 		t.Fatalf("Load(): %v", err)
 	}
@@ -715,7 +715,7 @@ func TestCacheMaxMBKVOverride(t *testing.T) {
 }
 
 func TestCacheMaxMBZeroDisables(t *testing.T) {
-	srv := buildKVServer(t, map[string]string{"render/cache-max-mb": "0"})
+	srv := buildKVServer(t, map[string]string{"cache-max-mb": "0"})
 	if err := loadWithConsul(t, srv); err != nil {
 		t.Fatalf("Load(): %v", err)
 	}

--- a/config/consul_test.go
+++ b/config/consul_test.go
@@ -26,7 +26,7 @@ func TestConsulClientRecurseAndDecode(t *testing.T) {
 	const kvPrefix = "carbonio-preview/"
 	entries := []kvEntry{
 		// Real entries.
-		{Key: kvPrefix + "storage/fetch-timeout-seconds", Value: ptr(encodeB64("60"))},
+		{Key: kvPrefix + "image-document/fetch-timeout-seconds", Value: ptr(encodeB64("60"))},
 		{Key: kvPrefix + "storages/download-api", Value: ptr(encodeB64("get"))},
 		// Null Value — must be filtered out.
 		{Key: kvPrefix + "workers", Value: nil},
@@ -67,8 +67,8 @@ func TestConsulClientRecurseAndDecode(t *testing.T) {
 	}
 
 	// Real entries: slash→dot conversion applied.
-	if m["storage.fetch-timeout-seconds"] != "60" {
-		t.Errorf("storage.fetch-timeout-seconds = %q, want %q", m["storage.fetch-timeout-seconds"], "60")
+	if m["image-document.fetch-timeout-seconds"] != "60" {
+		t.Errorf("image-document.fetch-timeout-seconds = %q, want %q", m["image-document.fetch-timeout-seconds"], "60")
 	}
 	if m["storages.download-api"] != "get" {
 		t.Errorf("storages.download-api = %q, want %q", m["storages.download-api"], "get")

--- a/config/migrate/cemig/cemig_test.go
+++ b/config/migrate/cemig/cemig_test.go
@@ -358,10 +358,11 @@ func TestHasApplicationWork_TrueWhenAbsentDueToV1Moves(t *testing.T) {
 // the opposite (false) before V1MoveDBPoolKeys existed: an ini containing
 // ONLY the bootstrap's drop-only keys did not require SETUP_CONSUL_TOKEN,
 // because the bootstrap's application-layer work is driven entirely by the
-// ini. Now that V1MoveDBPoolKeys' ApplicationKVMoves are registered in the
-// same "ce" set, they always talk to Consul KV regardless of what the ini
-// contains, so HasApplicationWork is true and a full run does touch Consul
-// (one Get(OldPath) probe per move, finding nothing to move).
+// ini. Now that V1MoveDBPoolKeys and V2RenameConfigNamespaces' ApplicationKVMoves
+// are registered in the same "ce" set, they always talk to Consul KV
+// regardless of what the ini contains, so HasApplicationWork is true and a
+// full run does touch Consul (one Get(OldPath) probe per move across BOTH
+// migrations, finding nothing to move).
 func TestHasApplicationWork_TrueWhenOnlyDropEntriesDueToV1Moves(t *testing.T) {
 	dir := t.TempDir()
 	// ini with ONLY drop-only keys — no bootstrap application KV entries.
@@ -381,13 +382,14 @@ func TestHasApplicationWork_TrueWhenOnlyDropEntriesDueToV1Moves(t *testing.T) {
 		t.Fatalf("NewRunner: %v", err)
 	}
 	if !runner.HasApplicationWork() {
-		t.Error("HasApplicationWork must be true: V1MoveDBPoolKeys' ApplicationKVMoves always count as application work, regardless of the ini's content")
+		t.Error("HasApplicationWork must be true: V1MoveDBPoolKeys' and V2RenameConfigNamespaces' ApplicationKVMoves always count as application work, regardless of the ini's content")
 	}
 
-	// A full run against a reachable Consul stub (no pool.* keys pre-seeded,
-	// so every GET is a clean 404) must still complete cleanly: the
-	// bootstrap's drop-only keys are consumed from the ini, and
-	// V1MoveDBPoolKeys' moves are no-ops (old paths absent).
+	// A full run against a reachable Consul stub (no pool.*/render.*/storage.*
+	// keys pre-seeded, so every GET is a clean 404) must still complete
+	// cleanly: the bootstrap's drop-only keys are consumed from the ini, and
+	// both V1MoveDBPoolKeys' and V2RenameConfigNamespaces' moves are no-ops
+	// (old paths absent).
 	consulHits := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		consulHits++
@@ -408,10 +410,11 @@ func TestHasApplicationWork_TrueWhenOnlyDropEntriesDueToV1Moves(t *testing.T) {
 	}
 	runner2.Run()
 
-	// V1MoveDBPoolKeys issues exactly one Get(OldPath) per declared move (3
-	// moves); none of them exist, so no Get(NewPath), Put, or Delete follows.
-	if consulHits != 3 {
-		t.Errorf("expected 3 Consul GETs (one OldPath probe per move), got %d", consulHits)
+	// V1MoveDBPoolKeys (3 moves) and V2RenameConfigNamespaces (4 moves) each
+	// issue exactly one Get(OldPath) per declared move; none of them exist, so
+	// no Get(NewPath), Put, or Delete follows. Total: 3 + 4 = 7.
+	if consulHits != 7 {
+		t.Errorf("expected 7 Consul GETs (one OldPath probe per move across V1+V2), got %d", consulHits)
 	}
 	// ini must have been renamed (all bootstrap keys consumed).
 	if _, err := os.Stat(iniPath); !os.IsNotExist(err) {

--- a/config/migrate/cemig/v2.go
+++ b/config/migrate/cemig/v2.go
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package cemig
+
+import "github.com/zextras/carbonio-preview-ce/v3/config/migrate"
+
+func init() {
+	if err := migrate.RegisterInSet("ce", V2RenameConfigNamespaces()); err != nil {
+		panic("cemig: register V2 into set \"ce\": " + err.Error())
+	}
+}
+
+// V2RenameConfigNamespaces returns the CE V2 migration — the second entry in
+// the "ce" set's KV→KV series — that moves four Consul KV keys to a clearer
+// namespace introduced on the refactor/kv-config-namespace branch (see
+// config/registry.go's application key block). Like V1MoveDBPoolKeys, this
+// migration talks to Consul KV directly (ApplicationKVMoves) and does NOT
+// touch the legacy Python config.ini, so it also applies to installs that
+// already completed the bootstrap (or never had a config.ini at all).
+//
+// Key moves (KV path = "carbonio-preview/" + dots→slashes, matching the
+// bootstrap's ApplicationEntries convention above) — all four are verbatim
+// value carry-overs, no Transform:
+//
+//	storage.fetch-timeout-seconds      -> image-document.fetch-timeout-seconds
+//	render.cache-max-mb                -> cache-max-mb                       (moves to root — no namespace prefix)
+//	render.max-concurrent-operations   -> image-document.max-concurrent-operations
+//	render.pdf-subprocess-pool-size    -> document.subprocess-pool-size
+//
+// The "render" namespace is retired by this move: image/PDF/document timeout
+// and concurrency knobs move under "image-document", the PDFium subprocess
+// pool moves under "document", and the rendered-output cache budget — which
+// is shared by ALL preview types including video, not just image/PDF/document
+// — moves to the root (no namespace prefix at all).
+func V2RenameConfigNamespaces() migrate.Migration {
+	return migrate.Migration{
+		Version: 2,
+		Name:    "V2__RenameConfigNamespaces",
+
+		// ── Application KV-to-KV moves (Consul KV, independent of the ini) ───────
+		ApplicationKVMoves: []migrate.KVMove{
+			{
+				OldPath: "carbonio-preview/storage/fetch-timeout-seconds",
+				NewPath: "carbonio-preview/image-document/fetch-timeout-seconds",
+			},
+			{
+				OldPath: "carbonio-preview/render/cache-max-mb",
+				NewPath: "carbonio-preview/cache-max-mb",
+			},
+			{
+				OldPath: "carbonio-preview/render/max-concurrent-operations",
+				NewPath: "carbonio-preview/image-document/max-concurrent-operations",
+			},
+			{
+				OldPath: "carbonio-preview/render/pdf-subprocess-pool-size",
+				NewPath: "carbonio-preview/document/subprocess-pool-size",
+			},
+		},
+	}
+}

--- a/config/migrate/cemig/v2_test.go
+++ b/config/migrate/cemig/v2_test.go
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package cemig
+
+import (
+	"testing"
+)
+
+// ── V2RenameConfigNamespaces (ApplicationKVMoves) end-to-end tests ───────────
+//
+// newV1Runner (defined in cemig_test.go) builds a runner against the "ce" set
+// with an ABSENT legacy ini; despite its V1-era name it is a generic "ce" set
+// runner and is reused here unchanged for V2's tests.
+
+// TestV2_MovesRenamedKeysToNewNamespace runs the real "ce" set end to end
+// (absent ini) against a Consul KV stub pre-seeded with the four pre-refactor
+// keys. It verifies the values land at the new paths (verbatim, no
+// transform) and the old keys are deleted.
+func TestV2_MovesRenamedKeysToNewNamespace(t *testing.T) {
+	data := map[string]string{
+		"carbonio-preview/storage/fetch-timeout-seconds":    "45",
+		"carbonio-preview/render/cache-max-mb":              "512",
+		"carbonio-preview/render/max-concurrent-operations": "4",
+		"carbonio-preview/render/pdf-subprocess-pool-size":  "2",
+	}
+	srv := newStatefulConsulKV(t, data)
+	runner := newV1Runner(t, srv.URL)
+
+	runner.Run()
+
+	if got := data["carbonio-preview/image-document/fetch-timeout-seconds"]; got != "45" {
+		t.Errorf("image-document/fetch-timeout-seconds = %q, want %q", got, "45")
+	}
+	if got := data["carbonio-preview/cache-max-mb"]; got != "512" {
+		t.Errorf("cache-max-mb = %q, want %q", got, "512")
+	}
+	if got := data["carbonio-preview/image-document/max-concurrent-operations"]; got != "4" {
+		t.Errorf("image-document/max-concurrent-operations = %q, want %q", got, "4")
+	}
+	if got := data["carbonio-preview/document/subprocess-pool-size"]; got != "2" {
+		t.Errorf("document/subprocess-pool-size = %q, want %q", got, "2")
+	}
+
+	for _, old := range []string{
+		"carbonio-preview/storage/fetch-timeout-seconds",
+		"carbonio-preview/render/cache-max-mb",
+		"carbonio-preview/render/max-concurrent-operations",
+		"carbonio-preview/render/pdf-subprocess-pool-size",
+	} {
+		if _, ok := data[old]; ok {
+			t.Errorf("old key %q must be deleted after a successful move", old)
+		}
+	}
+}
+
+// TestV2_NewKeyAlreadyPresent_NoClobber verifies the never-clobber arm for the
+// root-level "cache-max-mb" move: when an operator (or an earlier partial
+// run) has already set the new-style root key, V2RenameConfigNamespaces must
+// leave it untouched and must not delete the old key either (the move is
+// skipped entirely for that pair).
+func TestV2_NewKeyAlreadyPresent_NoClobber(t *testing.T) {
+	data := map[string]string{
+		"carbonio-preview/render/cache-max-mb": "512",
+		"carbonio-preview/cache-max-mb":        "999", // operator-set new-style value
+	}
+	srv := newStatefulConsulKV(t, data)
+	runner := newV1Runner(t, srv.URL)
+
+	runner.Run()
+
+	if got := data["carbonio-preview/cache-max-mb"]; got != "999" {
+		t.Errorf("cache-max-mb = %q, must never be clobbered (want %q)", got, "999")
+	}
+	if got := data["carbonio-preview/render/cache-max-mb"]; got != "512" {
+		t.Errorf("old key = %q, must survive untouched when the move is skipped (want %q)", got, "512")
+	}
+}
+
+// TestV2_OldKeyAbsent_NoOp verifies that when none of the four old keys
+// exist (a fresh install, or one that never had them), V2RenameConfigNamespaces
+// makes no writes and no deletes at all.
+func TestV2_OldKeyAbsent_NoOp(t *testing.T) {
+	data := map[string]string{}
+	srv := newStatefulConsulKV(t, data)
+	runner := newV1Runner(t, srv.URL)
+
+	runner.Run()
+
+	if len(data) != 0 {
+		t.Errorf("expected zero KV entries when old keys are absent, got %v", data)
+	}
+}
+
+// TestV1AndV2_BothApplyInASingleRun verifies that a single Run() against the
+// "ce" set executes BOTH V1MoveDBPoolKeys and V2RenameConfigNamespaces when
+// their respective old-style keys are all present — proving RegisterInSet
+// appends multiple migrations into the same set and Runner.Run() walks the
+// whole version-ascending series, not just the first entry.
+func TestV1AndV2_BothApplyInASingleRun(t *testing.T) {
+	data := map[string]string{
+		// V1 (database pool) old keys.
+		"carbonio-preview/database/pool/max-connections": "15",
+		// V2 (namespace rename) old keys.
+		"carbonio-preview/storage/fetch-timeout-seconds": "45",
+	}
+	srv := newStatefulConsulKV(t, data)
+	runner := newV1Runner(t, srv.URL)
+
+	runner.Run()
+
+	if got := data["carbonio-preview/database/db-pool-max-size"]; got != "15" {
+		t.Errorf("V1 move: db-pool-max-size = %q, want %q", got, "15")
+	}
+	if got := data["carbonio-preview/image-document/fetch-timeout-seconds"]; got != "45" {
+		t.Errorf("V2 move: image-document/fetch-timeout-seconds = %q, want %q", got, "45")
+	}
+}
+
+// TestV2_IdempotentSecondRun verifies that once the four keys have been moved,
+// a second Run() against the same (now new-style) data makes no further
+// changes.
+func TestV2_IdempotentSecondRun(t *testing.T) {
+	data := map[string]string{
+		"carbonio-preview/storage/fetch-timeout-seconds":    "45",
+		"carbonio-preview/render/cache-max-mb":              "512",
+		"carbonio-preview/render/max-concurrent-operations": "4",
+		"carbonio-preview/render/pdf-subprocess-pool-size":  "2",
+	}
+	srv := newStatefulConsulKV(t, data)
+	runner := newV1Runner(t, srv.URL)
+	runner.Run()
+
+	// Second run against the now-migrated data must be a clean no-op.
+	runner2 := newV1Runner(t, srv.URL)
+	runner2.Run()
+
+	if got := data["carbonio-preview/image-document/fetch-timeout-seconds"]; got != "45" {
+		t.Errorf("second run: image-document/fetch-timeout-seconds = %q, want %q (unchanged)", got, "45")
+	}
+	if got := data["carbonio-preview/cache-max-mb"]; got != "512" {
+		t.Errorf("second run: cache-max-mb = %q, want %q (unchanged)", got, "512")
+	}
+	for _, old := range []string{
+		"carbonio-preview/storage/fetch-timeout-seconds",
+		"carbonio-preview/render/cache-max-mb",
+		"carbonio-preview/render/max-concurrent-operations",
+		"carbonio-preview/render/pdf-subprocess-pool-size",
+	} {
+		if _, ok := data[old]; ok {
+			t.Errorf("old key %q must remain deleted after a second run", old)
+		}
+	}
+}

--- a/config/naming.go
+++ b/config/naming.go
@@ -37,8 +37,8 @@ const (
 //	EnvName("networking-config.", "carbonio.service.host")
 //	  → "NETWORKING_CONFIG_CARBONIO_SERVICE_HOST"
 //
-//	EnvName("application-config.", "storage.fetch-timeout-seconds")
-//	  → "APPLICATION_CONFIG_STORAGE_FETCH_TIMEOUT_SECONDS"
+//	EnvName("application-config.", "image-document.fetch-timeout-seconds")
+//	  → "APPLICATION_CONFIG_IMAGE_DOCUMENT_FETCH_TIMEOUT_SECONDS"
 func EnvName(prefix, key string) string {
 	combined := prefix + key
 	combined = strings.ToUpper(combined)

--- a/config/naming_test.go
+++ b/config/naming_test.go
@@ -24,8 +24,8 @@ func TestEnvName(t *testing.T) {
 		},
 		{
 			prefix: ApplicationPrefix,
-			key:    "storage.fetch-timeout-seconds",
-			want:   "APPLICATION_CONFIG_STORAGE_FETCH_TIMEOUT_SECONDS",
+			key:    "image-document.fetch-timeout-seconds",
+			want:   "APPLICATION_CONFIG_IMAGE_DOCUMENT_FETCH_TIMEOUT_SECONDS",
 		},
 		{
 			prefix: ApplicationPrefix,
@@ -48,7 +48,7 @@ func TestKvPath(t *testing.T) {
 		want string
 	}{
 		{"storages.download-api", "carbonio-preview/storages/download-api"},
-		{"storage.fetch-timeout-seconds", "carbonio-preview/storage/fetch-timeout-seconds"},
+		{"image-document.fetch-timeout-seconds", "carbonio-preview/image-document/fetch-timeout-seconds"},
 		{"docs-editor.service-endpoint", "carbonio-preview/docs-editor/service-endpoint"},
 	}
 
@@ -64,7 +64,7 @@ func TestKvPathRoundTrip(t *testing.T) {
 	// Verify that the suffix of the KV path, with / → . reverts to the original key.
 	keys := []string{
 		"storages.download-api",
-		"storage.fetch-timeout-seconds",
+		"image-document.fetch-timeout-seconds",
 		"docs-editor.service-endpoint",
 		"workers",
 	}

--- a/config/registry.go
+++ b/config/registry.go
@@ -240,7 +240,7 @@ func registerCEKeys() {
 			Description: "Whether document thumbnail generation is enabled.",
 		},
 		{
-			Key:         "storage.fetch-timeout-seconds",
+			Key:         "image-document.fetch-timeout-seconds",
 			Namespace:   NamespaceApplication,
 			Default:     "30",
 			Description: "Timeout (seconds) for fetching the source blob from carbonio-storages.",
@@ -252,24 +252,24 @@ func registerCEKeys() {
 			Description: "Timeout (seconds) for the docs-editor (Collabora) conversion call.",
 		},
 		{
-			Key:         "render.cache-max-mb",
+			Key:         "cache-max-mb",
 			Namespace:   NamespaceApplication,
 			Default:     "256",
-			Description: "Size budget (MiB) of the shared image/PDF/document rendered-output cache; 0 disables it.",
+			Description: "Size budget (MiB) of the global rendered-output cache shared by all preview types (image, PDF, document, video); 0 disables it.",
 		},
 		{
-			Key:          "render.max-concurrent-operations",
+			Key:          "image-document.max-concurrent-operations",
 			Namespace:    NamespaceApplication,
 			Default:      "", // computed at runtime → runtime.NumCPU()
 			IfNotPresent: "Defaults to the number of CPUs",
 			Description:  "Maximum render operations (image, PDF, document) processed concurrently; does not apply to video. Default: CPU count.",
 		},
 		{
-			Key:          "render.pdf-subprocess-pool-size",
+			Key:          "document.subprocess-pool-size",
 			Namespace:    NamespaceApplication,
 			Default:      "", // computed at runtime → runtime.NumCPU()
 			IfNotPresent: "Defaults to the number of CPUs",
-			Description:  "Number of PDFium helper OS subprocesses used for PDF/document rendering; a render acquires one after passing render/max-concurrent-operations. Default: CPU count.",
+			Description:  "Number of PDFium helper OS subprocesses used for PDF/document rendering; a render acquires one after passing image-document/max-concurrent-operations. Default: CPU count.",
 		},
 		{
 			Key:          "video.max-concurrent-extractions",

--- a/config/registry_test.go
+++ b/config/registry_test.go
@@ -53,10 +53,10 @@ func TestRegisteredCEApplicationKeys(t *testing.T) {
 	required := []string{
 		"document.enable-preview",
 		"document.enable-thumbnail",
-		"storage.fetch-timeout-seconds",
+		"image-document.fetch-timeout-seconds",
 		"document.conversion-timeout-seconds",
-		"render.max-concurrent-operations",
-		"render.pdf-subprocess-pool-size",
+		"image-document.max-concurrent-operations",
+		"document.subprocess-pool-size",
 		"video.max-concurrent-extractions",
 	}
 
@@ -77,11 +77,11 @@ func TestRegisteredCEApplicationKeys(t *testing.T) {
 		"document.enable-thumbnail": false,
 		// Documented (not hidden): an operator's customized timeout is migrated
 		// into these KV keys on upgrade, so they must be discoverable in docs.
-		"storage.fetch-timeout-seconds":       false,
-		"document.conversion-timeout-seconds": false,
-		"render.max-concurrent-operations":    false,
-		"render.pdf-subprocess-pool-size":     false,
-		"video.max-concurrent-extractions":    false,
+		"image-document.fetch-timeout-seconds":     false,
+		"document.conversion-timeout-seconds":      false,
+		"image-document.max-concurrent-operations": false,
+		"document.subprocess-pool-size":            false,
+		"video.max-concurrent-extractions":         false,
 	}
 	for k, wantHidden := range hiddenExpected {
 		e, ok := idx[k]
@@ -133,7 +133,7 @@ func TestKeyDefaults(t *testing.T) {
 	appChecks := []struct{ key, dflt, ifNotPresent string }{
 		{"document.enable-preview", "true", ""},
 		{"document.enable-thumbnail", "false", ""},
-		{"storage.fetch-timeout-seconds", "30", ""},
+		{"image-document.fetch-timeout-seconds", "30", ""},
 		{"document.conversion-timeout-seconds", "15", ""},
 		// DB pool: the lifetime default is MILLISECONDS (600000 = 10 min).
 		// Do NOT "fix" it back to 600 — that would reintroduce the 1000x
@@ -141,8 +141,8 @@ func TestKeyDefaults(t *testing.T) {
 		{"database.db-pool-max-lifetime", "600000", ""},
 		{"database.db-pool-max-size", "10", ""},
 		{"database.db-pool-min-size", "2", ""},
-		{"render.max-concurrent-operations", "", "Defaults to the number of CPUs"},
-		{"render.pdf-subprocess-pool-size", "", "Defaults to the number of CPUs"},
+		{"image-document.max-concurrent-operations", "", "Defaults to the number of CPUs"},
+		{"document.subprocess-pool-size", "", "Defaults to the number of CPUs"},
 		{"video.max-concurrent-extractions", "", "Defaults to the number of CPUs"},
 	}
 	for _, tc := range appChecks {
@@ -288,6 +288,7 @@ func TestRegisteredKeysSortOrder(t *testing.T) {
 	// Spot-check: known application keys that must appear in alphabetical order.
 	// The list includes all registered application keys (db-pool-*, video-*, etc.).
 	appExpected := []string{
+		"cache-max-mb",
 		"database.credentials.db-name",
 		"database.credentials.db-password",
 		"database.credentials.db-username",
@@ -297,10 +298,9 @@ func TestRegisteredKeysSortOrder(t *testing.T) {
 		"document.conversion-timeout-seconds",
 		"document.enable-preview",
 		"document.enable-thumbnail",
-		"render.cache-max-mb",
-		"render.max-concurrent-operations",
-		"render.pdf-subprocess-pool-size",
-		"storage.fetch-timeout-seconds",
+		"document.subprocess-pool-size",
+		"image-document.fetch-timeout-seconds",
+		"image-document.max-concurrent-operations",
 		"video.max-attempts",
 		"video.max-concurrent-extractions",
 		"video.poll-interval-seconds",
@@ -318,17 +318,16 @@ func TestRegisteredKeysSortOrder(t *testing.T) {
 	}
 }
 
-
 func TestCacheMaxMBRegistered(t *testing.T) {
 	m := registeredKeyMap(NamespaceApplication)
-	e, ok := m["render.cache-max-mb"]
+	e, ok := m["cache-max-mb"]
 	if !ok {
-		t.Fatal("application key \"render.cache-max-mb\" not registered")
+		t.Fatal("application key \"cache-max-mb\" not registered")
 	}
 	if e.Default != "256" {
-		t.Errorf("render.cache-max-mb default = %q, want \"256\"", e.Default)
+		t.Errorf("cache-max-mb default = %q, want \"256\"", e.Default)
 	}
 	if e.HiddenFromDocs {
-		t.Error("render.cache-max-mb must be visible in docs (HiddenFromDocs=false)")
+		t.Error("cache-max-mb must be visible in docs (HiddenFromDocs=false)")
 	}
 }

--- a/configdocs/render_test.go
+++ b/configdocs/render_test.go
@@ -209,7 +209,7 @@ func TestConditionalThirdColumn_PerSection(t *testing.T) {
 	docs := configdocs.BuildDocs("carbonio-preview", "preview", []configdocs.RawKey{
 		{Key: "carbonio.service.host", Namespace: "networking", Default: "127.0.0.1"},
 		{Key: "workers", Namespace: "application", Default: "2"},
-		{Key: "render.pdf-subprocess-pool-size", Namespace: "application", Default: "", IfNotPresent: "Defaults to CPUs"},
+		{Key: "document.subprocess-pool-size", Namespace: "application", Default: "", IfNotPresent: "Defaults to CPUs"},
 	})
 	md := configdocs.RenderMd(docs)
 
@@ -234,14 +234,14 @@ func TestConditionalThirdColumn_PerSection(t *testing.T) {
 func TestKvPathDisplay(t *testing.T) {
 	docs := configdocs.BuildDocs("carbonio-preview", "preview", []configdocs.RawKey{
 		{Key: "storages.download-api", Namespace: "application", Default: "download"},
-		{Key: "storage.fetch-timeout-seconds", Namespace: "application", Default: "30"},
+		{Key: "image-document.fetch-timeout-seconds", Namespace: "application", Default: "30"},
 	})
 	md := configdocs.RenderMd(docs)
 	if !strings.Contains(md, "carbonio-preview/storages/download-api") {
 		t.Errorf("expected KV path 'carbonio-preview/storages/download-api'; got:\n%s", md)
 	}
-	if !strings.Contains(md, "carbonio-preview/storage/fetch-timeout-seconds") {
-		t.Errorf("expected KV path 'carbonio-preview/storage/fetch-timeout-seconds'; got:\n%s", md)
+	if !strings.Contains(md, "carbonio-preview/image-document/fetch-timeout-seconds") {
+		t.Errorf("expected KV path 'carbonio-preview/image-document/fetch-timeout-seconds'; got:\n%s", md)
 	}
 	// Networking keys should appear as raw dot-notation.
 	docs2 := configdocs.BuildDocs("carbonio-preview", "preview", []configdocs.RawKey{
@@ -271,7 +271,7 @@ func TestHiddenFromDocs_Filtered(t *testing.T) {
 }
 
 // TestTimeoutKeysPresentInGeneratedDocs verifies that the live registry's
-// timeout keys ("storage/fetch-timeout-seconds", "document/conversion-timeout-seconds")
+// timeout keys ("image-document/fetch-timeout-seconds", "document/conversion-timeout-seconds")
 // ARE present in the rendered md output. They are documented (not hidden) because
 // the V1 upgrade migration carries an operator's customized timeout into these
 // Consul KV keys, so operators must be able to discover them.
@@ -280,7 +280,7 @@ func TestTimeoutKeysPresentInGeneratedDocs(t *testing.T) {
 	md := configdocs.RenderMd(docs)
 
 	for _, key := range []string{
-		"carbonio-preview/storage/fetch-timeout-seconds",
+		"carbonio-preview/image-document/fetch-timeout-seconds",
 		"carbonio-preview/document/conversion-timeout-seconds",
 	} {
 		if !strings.Contains(md, key) {

--- a/docs/configs.md
+++ b/docs/configs.md
@@ -31,6 +31,7 @@ Overridable by Consul KV
 
 | Key | Default | If not set |
 | --- | ------- | ---------- |
+| `carbonio-preview/cache-max-mb` | `256` |  |
 | `carbonio-preview/database/credentials/db-name` | *(not set)* | Crashes; but always set by database bootstrap |
 | `carbonio-preview/database/credentials/db-password` | *(not set)* | Crashes; but always set by database bootstrap |
 | `carbonio-preview/database/credentials/db-username` | *(not set)* | Crashes; but always set by database bootstrap |
@@ -40,10 +41,9 @@ Overridable by Consul KV
 | `carbonio-preview/document/conversion-timeout-seconds` | `15` |  |
 | `carbonio-preview/document/enable-preview` | `true` |  |
 | `carbonio-preview/document/enable-thumbnail` | `false` |  |
-| `carbonio-preview/render/cache-max-mb` | `256` |  |
-| `carbonio-preview/render/max-concurrent-operations` | *(not set)* | Defaults to the number of CPUs |
-| `carbonio-preview/render/pdf-subprocess-pool-size` | *(not set)* | Defaults to the number of CPUs |
-| `carbonio-preview/storage/fetch-timeout-seconds` | `30` |  |
+| `carbonio-preview/document/subprocess-pool-size` | *(not set)* | Defaults to the number of CPUs |
+| `carbonio-preview/image-document/fetch-timeout-seconds` | `30` |  |
+| `carbonio-preview/image-document/max-concurrent-operations` | *(not set)* | Defaults to the number of CPUs |
 | `carbonio-preview/video/max-attempts` | `3` |  |
 | `carbonio-preview/video/max-concurrent-extractions` | *(not set)* | Defaults to the number of CPUs |
 | `carbonio-preview/video/poll-interval-seconds` | `15` |  |

--- a/render/pdf.go
+++ b/render/pdf.go
@@ -76,7 +76,7 @@ func PDFClose() {
 // Concurrency model:
 //   - semaphore (N_http / workers) gates handler-level processing; pass nil
 //     to skip gating (not recommended in production).
-//   - The PDFium subprocess pool (N_pdf / render.pdf-subprocess-pool-size) is
+//   - The PDFium subprocess pool (N_pdf / document.subprocess-pool-size) is
 //     the second gate: GetInstance blocks until a subprocess worker is free or the timeout
 //     fires. The http gate sits in front so the pool is never flooded.
 //
@@ -171,7 +171,7 @@ func PDFRasterize(
 // Concurrency model:
 //   - semaphore (N_http / workers) gates handler-level processing; pass nil
 //     to skip gating (not recommended in production).
-//   - The PDFium subprocess pool (N_pdf / render.pdf-subprocess-pool-size) is
+//   - The PDFium subprocess pool (N_pdf / document.subprocess-pool-size) is
 //     the second gate. The http gate sits in front so the pool is never flooded.
 //
 // Invalid PDFs: returns (nil, error). Callers should map this to HTTP 400.

--- a/server/api.go
+++ b/server/api.go
@@ -37,7 +37,7 @@ type Deps struct {
 	Store storage.Client
 	Cache *cache.Cache
 	// Sem is the shared render semaphore (image/PDF/document ops), sized by the
-	// render.max-concurrent-operations key.
+	// image-document.max-concurrent-operations key.
 	Sem chan struct{}
 	// VideoSem is the DEDICATED video semaphore (capacity =
 	// video.max-concurrent-extractions, default NumCPU). Separate from Sem so a

--- a/server/server.go
+++ b/server/server.go
@@ -209,7 +209,7 @@ func (s *Server) Handler() http.Handler {
 // registered under huma (code-first OpenAPI).
 //
 // sem is the shared render semaphore (image/PDF/document), sized by the
-// render.max-concurrent-operations key. The dedicated video semaphore is built
+// image-document.max-concurrent-operations key. The dedicated video semaphore is built
 // here from cfg.VideoConcurrency (APPLICATION key
 // video.max-concurrent-extractions, default runtime.NumCPU()) so a flood of
 // video jobs can never starve image previews, and vice-versa.


### PR DESCRIPTION
## What

Reorganizes the application-layer Consul-KV config keys into clearer namespaces that state **which file types a key applies to**, and adds a **V2 KV→KV migration** so existing installs are renamed automatically at setup.

The vague `render/` namespace is removed:
- keys **shared by the image + document pipelines** → `image-document/`
- the **PDFium subprocess pool** (document-engine specific) → `document/`
- the **rendered-output cache** (used by *every* preview type, video included) → **root**

This is a **behavior-preserving rename**. No timeout/semantics change; `video/*`, `database/*` and the remaining `document.*` keys are untouched.

## Renames

| Old key | New key | Applies to |
|---|---|---|
| `storage/fetch-timeout-seconds` | `image-document/fetch-timeout-seconds` | image + document (buffered fetch; video streaming is not bounded by it, by design) |
| `render/cache-max-mb` | `cache-max-mb` (root) | all preview types (global result cache) |
| `render/max-concurrent-operations` | `image-document/max-concurrent-operations` | image + PDF + document render semaphore (not video) |
| `render/pdf-subprocess-pool-size` | `document/subprocess-pool-size` | PDF + document (PDFium pool) |

## Migration

`config/migrate/cemig/v2.go` — `V2__RenameConfigNamespaces`, four verbatim `KVMove`s in the `"ce"` set, ordered after bootstrap → V1.
- Absent source → no-op; existing target → **never clobbers**; idempotent (re-run safe).
- Applies directly against Consul KV, so it covers both fresh Python→Go imports (bootstrap writes the old path, V2 moves it) and already-Go installs.
- `bootstrap_ini.go` deliberately left writing the historical `storage/fetch-timeout-seconds` path — V2 moves it immediately after.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` — all green (fresh, uncached).
- New `v2_test.go`: 4-key move, no-clobber, absent-source no-op, idempotency, V1+V2 single-run coexistence.
- `docs/configs.md` regenerated via `go generate` — byte-identical to generator output (no `render/*`, `cache-max-mb` at root, new namespaces present).
- Independent adversarial review: **SHIP** (rename completeness, dotless-root-key KV/env mapping, migration safety all verified).

## Notes for reviewers

- **Operator-facing key change.** Standard upgrades are seamless (the migration preserves customized values). External automation that writes the *old* KV paths directly would write dead keys post-upgrade. Flagging in case you want to treat the release semantics accordingly.
- **Advanced edition follow-up (out of scope here).** The Advanced edition runs its own `"advanced"` migration set/bootstrap and shares this `config` package's read side. Before the release wave it must ship (a) the same registry rename and (b) an equivalent V2 in its `"advanced"` set, or Advanced upgrades will read the new key names, find them absent, and fall back to defaults for these 4 knobs. Separate PR, after this one merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
