### PR TITLE
fix(storage): apply fetch-timeout as a total buffered-fetch cap (match Advanced)

### DIFF
--- a/storage/direct.go
+++ b/storage/direct.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"log/slog"
 	"mime/multipart"
-	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -36,7 +35,16 @@ type DirectClient struct {
 	downloadURL string // pre-built base URL including the API path, e.g. "http://127.78.0.6:20000/download"
 	uploadURL   string // e.g. "http://127.78.0.6:20000/upload"
 	deleteURL   string // e.g. "http://127.78.0.6:20000/delete"
-	http        *http.Client
+	// httpClient is used for the buffered operations: RetrieveData, StoreData,
+	// and Delete. It carries fetchTimeout as a hard wall-clock cap covering the
+	// full request lifecycle (connect + TLS + write + read-entire-body).
+	httpClient *http.Client
+	// streamClient is used exclusively by RetrieveDataStreaming. It has
+	// Timeout:0 so the overall response-body read is never capped by a
+	// wall-clock timer — a large video download is not aborted mid-stream.
+	// The caller's ctx (and, in the video worker, the idle-read watchdog) is
+	// the actual stall protection for streaming downloads.
+	streamClient *http.Client
 }
 
 // NewDirectClient constructs a DirectClient.
@@ -45,24 +53,33 @@ type DirectClient struct {
 //   - downloadAPI    — path segment for GET download, e.g. "download"
 //   - uploadAPI      — path segment for POST upload, e.g. "upload"
 //   - deleteAPI      — path segment for DELETE, e.g. "delete"
-//   - dialTimeout    — bounds TCP connection establishment and TLS handshake ONLY.
-//     There is intentionally NO http.Client.Timeout (no total-request cap here):
-//     the operation deadline is the per-request ctx deadline set by the handler,
-//     which governs the full lifecycle (download + ffmpeg + render) via a single
-//     context.WithTimeout. The body read is cancelled automatically when that
-//     ctx fires, because every request is built with http.NewRequestWithContext.
-func NewDirectClient(storageBaseURL, downloadAPI, uploadAPI, deleteAPI string, dialTimeout time.Duration) *DirectClient {
-	transport := &http.Transport{
-		DialContext: (&net.Dialer{
-			Timeout: dialTimeout,
-		}).DialContext,
-		TLSHandshakeTimeout: dialTimeout,
-	}
+//   - fetchTimeout   — TOTAL wall-clock timeout applied to the buffered
+//     operations (RetrieveData, StoreData, Delete) via http.Client.Timeout.
+//     This bounds connect + TLS handshake + request write + full body read
+//     as one deadline — mirroring the Advanced edition's PowerStoreClient
+//     (internal/powerstore/powerstore.go), which uses the same value as its
+//     httpClient.Timeout.
+//
+// RetrieveDataStreaming does NOT use fetchTimeout: it is served by a separate
+// streamClient with Timeout:0, so a legitimate large video download is never
+// aborted by this wall-clock cap. Both clients share one empty *http.Transport
+// (no DialContext/TLSHandshakeTimeout override) — there is no separate dial
+// timeout because fetchTimeout on httpClient already bounds connect+TLS+body
+// for the buffered path, and the streaming path is deliberately unbounded.
+func NewDirectClient(storageBaseURL, downloadAPI, uploadAPI, deleteAPI string, fetchTimeout time.Duration) *DirectClient {
+	sharedTransport := &http.Transport{}
 	return &DirectClient{
 		downloadURL: storageBaseURL + "/" + downloadAPI,
 		uploadURL:   storageBaseURL + "/" + uploadAPI,
 		deleteURL:   storageBaseURL + "/" + deleteAPI,
-		http:        &http.Client{Transport: transport},
+		httpClient: &http.Client{
+			Timeout:   fetchTimeout,
+			Transport: sharedTransport,
+		},
+		streamClient: &http.Client{
+			Timeout:   0,
+			Transport: sharedTransport,
+		},
 	}
 }
 
@@ -91,7 +108,7 @@ func (c *DirectClient) RetrieveData(
 	}
 
 	start := time.Now()
-	resp, err := c.http.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		// Any transport-level error (timeout, DNS, connection refused, etc.)
 		// maps to ErrUnavailable, mirroring the Python Nothing path.
@@ -136,6 +153,12 @@ func (c *DirectClient) RetrieveData(
 // RetrieveDataStreaming is the streaming variant of RetrieveData. It performs
 // the identical GET but returns resp.Body so the caller can read a prefix and
 // close early. The body MUST be closed by the caller.
+//
+// It is served by streamClient (Timeout:0), NOT httpClient — the buffered
+// fetchTimeout wall-clock cap does not apply here, so a legitimate large
+// video download is never aborted mid-stream. Cancelling ctx still aborts the
+// in-flight transfer; the video worker's idle-read watchdog uses this to
+// bound stalled downloads at the byte-progress level instead.
 func (c *DirectClient) RetrieveDataStreaming(
 	ctx context.Context,
 	fileID string,
@@ -151,7 +174,7 @@ func (c *DirectClient) RetrieveDataStreaming(
 	if err != nil {
 		return nil, fmt.Errorf("%w: creating request: %v", ErrUnavailable, err)
 	}
-	resp, err := c.http.Do(req)
+	resp, err := c.streamClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrUnavailable, err)
 	}
@@ -217,7 +240,7 @@ func (c *DirectClient) StoreData(
 	req.Header.Set("Content-Type", mw.FormDataContentType())
 
 	start := time.Now()
-	resp, err := c.http.Do(req)
+	resp, err := c.httpClient.Do(req)
 	durationMs := time.Since(start).Milliseconds()
 	if err != nil {
 		slog.Debug("storage: upload request failed",
@@ -275,7 +298,7 @@ func (c *DirectClient) Delete(
 	}
 
 	start := time.Now()
-	resp, err := c.http.Do(req)
+	resp, err := c.httpClient.Do(req)
 	durationMs := time.Since(start).Milliseconds()
 	if err != nil {
 		slog.Debug("storage: delete request failed",

--- a/storage/direct_test.go
+++ b/storage/direct_test.go
@@ -136,10 +136,10 @@ func TestRetrieveData_ConnectionRefused(t *testing.T) {
 // TestRetrieveData_CtxTimeout verifies that a request whose context deadline
 // fires while the server is hanging maps to ErrUnavailable.
 //
-// The storage client carries no total-request http.Client.Timeout; the
-// per-request deadline is provided by the caller's context (mirroring the
-// single-clock design where the video handler's context.WithTimeout governs
-// the full operation). A very short context deadline keeps the test fast.
+// The buffered httpClient also carries a total fetchTimeout (5s here), but
+// the ctx deadline (50ms) is far shorter and fires first — proving ctx-based
+// cancellation still works independently of, and in addition to, the total
+// wall-clock cap introduced by fetchTimeout.
 func TestRetrieveData_CtxTimeout(t *testing.T) {
 	// Server that never responds (hangs until ctx is cancelled).
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -153,6 +153,43 @@ func TestRetrieveData_CtxTimeout(t *testing.T) {
 	_, err := client.RetrieveData(ctx, "some-id", 1, "files", "")
 	if !errors.Is(err, ErrUnavailable) {
 		t.Errorf("expected ErrUnavailable on ctx timeout, got %v", err)
+	}
+}
+
+// TestRetrieveData_TotalFetchTimeout_SlowBody verifies that RetrieveData is
+// bounded by fetchTimeout as a TOTAL wall-clock cap — even with an unbounded
+// caller ctx (context.Background()), and even when the server has already
+// sent response headers and started streaming the body. Before this fix,
+// fetchTimeout (then named dialTimeout) only bounded TCP connect + TLS
+// handshake, so a slow body past those phases would hang indefinitely absent
+// a ctx deadline. This proves the buffered path can no longer do that.
+func TestRetrieveData_TotalFetchTimeout_SlowBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		_, _ = w.Write([]byte("first-chunk"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		// Stall past fetchTimeout without ever finishing the body.
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	const fetchTimeout = 150 * time.Millisecond
+	client := NewDirectClient(srv.URL, "download", "upload", "delete", fetchTimeout)
+
+	start := time.Now()
+	_, err := client.RetrieveData(context.Background(), "some-id", 1, "files", "")
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("expected ErrUnavailable from total fetch timeout, got %v", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("elapsed = %v, expected the total fetchTimeout (%v) to bound the request, not hang", elapsed, fetchTimeout)
 	}
 }
 
@@ -263,7 +300,7 @@ func (errBodyRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
 func TestRetrieveData_BodyReadError(t *testing.T) {
 	client := &DirectClient{
 		downloadURL: "http://127.0.0.1:20000/download",
-		http:        &http.Client{Transport: errBodyRoundTripper{}},
+		httpClient:  &http.Client{Transport: errBodyRoundTripper{}},
 	}
 	_, err := client.RetrieveData(context.Background(), "id", 1, "files", "")
 	if err == nil {
@@ -291,7 +328,7 @@ func TestBuildURL_ParseError(t *testing.T) {
 func TestRetrieveData_BuildURLError(t *testing.T) {
 	client := &DirectClient{
 		downloadURL: "http://[::1", // unparseable
-		http:        &http.Client{},
+		httpClient:  &http.Client{},
 	}
 	_, err := client.RetrieveData(context.Background(), "id", 1, "files", "")
 	if err == nil {
@@ -339,6 +376,104 @@ func TestRetrieveDataStreaming_404(t *testing.T) {
 	_, err := client.RetrieveDataStreaming(context.Background(), "x", 1, "files", "")
 	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("want ErrNotFound, got %v", err)
+	}
+}
+
+// TestRetrieveDataStreaming_ExceedsFetchTimeout_NotAborted verifies that
+// RetrieveDataStreaming is served by streamClient (Timeout: 0), NOT the
+// buffered httpClient (Timeout: fetchTimeout). A body that trickles in over
+// a duration far longer than fetchTimeout must still be delivered in full —
+// proving the streaming path has no total wall-clock cap, unlike the
+// buffered path (see TestRetrieveData_TotalFetchTimeout_SlowBody).
+func TestRetrieveDataStreaming_ExceedsFetchTimeout_NotAborted(t *testing.T) {
+	const chunkDelay = 60 * time.Millisecond
+	chunks := []string{"chunk0-", "chunk1-", "chunk2-", "chunk3"}
+	want := strings.Join(chunks, "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		if flusher != nil {
+			// Flush headers immediately (before any sleep) so Do() returns
+			// promptly and every chunkDelay below happens during the
+			// subsequent io.ReadAll, making the elapsed measurement below
+			// deterministic.
+			flusher.Flush()
+		}
+		for _, c := range chunks {
+			time.Sleep(chunkDelay)
+			_, _ = w.Write([]byte(c))
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+	}))
+	defer srv.Close()
+
+	// fetchTimeout is much shorter than the total time the body takes to
+	// arrive (len(chunks) * chunkDelay). If RetrieveDataStreaming used the
+	// buffered httpClient, this transfer would be aborted partway through.
+	const fetchTimeout = 80 * time.Millisecond
+	client := NewDirectClient(srv.URL, "download", "upload", "delete", fetchTimeout)
+
+	rc, err := client.RetrieveDataStreaming(context.Background(), "node-1", 1, "files", "")
+	if err != nil {
+		t.Fatalf("RetrieveDataStreaming: %v", err)
+	}
+	defer rc.Close()
+
+	start := time.Now()
+	got, err := io.ReadAll(rc)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("reading streamed body: %v (elapsed %v, fetchTimeout %v)", err, elapsed, fetchTimeout)
+	}
+	if string(got) != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+	if elapsed < time.Duration(len(chunks))*chunkDelay {
+		t.Errorf("elapsed = %v, want >= %v (chunks should have trickled in over time)", elapsed, time.Duration(len(chunks))*chunkDelay)
+	}
+}
+
+// TestRetrieveDataStreaming_CtxCancel_AbortsDespiteUnboundedTimeout verifies
+// that, even though streamClient carries no wall-clock Timeout, cancelling
+// the caller's ctx still aborts an in-flight streaming download. fetchTimeout
+// is deliberately large (5s) so that if the read is aborted quickly, it can
+// only be due to ctx cancellation — not a client-side timeout.
+func TestRetrieveDataStreaming_CtxCancel_AbortsDespiteUnboundedTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		// Hang until the client aborts the connection.
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	client := NewDirectClient(srv.URL, "download", "upload", "delete", 5*time.Second)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	rc, err := client.RetrieveDataStreaming(ctx, "node-1", 1, "files", "")
+	if err != nil {
+		t.Fatalf("RetrieveDataStreaming: %v", err)
+	}
+	defer rc.Close()
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err = io.ReadAll(rc)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected read to be aborted by ctx cancellation, got nil error")
+	}
+	if elapsed > 1*time.Second {
+		t.Errorf("elapsed = %v, expected ctx cancellation (~50ms) to abort well before fetchTimeout (5s)", elapsed)
 	}
 }
 


### PR DESCRIPTION
## What

Fixes a CE/Advanced behavior divergence on the `image-document/fetch-timeout-seconds` KV.

Same key, same 30s default — but it did different things per edition:

| Edition | Before |
|---|---|
| **Advanced** | total `http.Client.Timeout` (connect + full body read) on the buffered fetch |
| **CE** | **only** the dial + TLS-handshake timeout — the buffered body read had **no cap at all** |

This PR makes **CE mirror Advanced**, so the key means the same thing in both.

## Change (CE-only, `storage/direct.go`)

Split `DirectClient`'s single HTTP client into two, over an empty shared transport (no separate dial timeout — the total already bounds connect+TLS+body):

- `httpClient {Timeout: fetchTimeout}` → `RetrieveData`, `StoreData`, `Delete` (buffered)
- `streamClient {Timeout: 0}` → `RetrieveDataStreaming` (raw video download, **stays unbounded**)

The KV key and its registry description are **unchanged** — only *how* CE uses the value changes.

## Effect

- Buffered image/PDF/document fetches (and the small generated-preview uploads/deletes) are now bounded by the 30s total — matching Advanced, and closing a latent hang (the old CE client had no body cap).
- **Raw video download is unchanged**: `streamClient` is unbounded; a large video is never wall-clock-aborted (only the per-request ctx / 60s idle-read watchdog stops it).
- 30s is validated by Advanced, which has shipped this exact cap in production.

## No Advanced PR needed

The client code is **edition-specific**: `DirectClient` (`storage/direct.go`) is CE-only; Advanced uses its own `powerstore.go`, which **already** implements this two-client model. Advanced does not import CE's client code, and this PR changes **no shared config surface** (no KV rename, no registry/description change, no migration) — so bumping the CE pin on Advanced would carry no behavioral change. Advanced is intentionally left untouched.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` — all green (incl. video worker + Postgres testcontainer tests; new streaming tests run 5× / `-race` with no flakiness).
- New tests: buffered `RetrieveData` aborts when the body stalls past the total (no ctx deadline needed); `RetrieveDataStreaming` streams a body that trickles past `fetchTimeout` without aborting (proves `Timeout:0`); ctx cancellation still aborts a stream promptly.
- Independent adversarial review: **SHIP** — verified via caller trace that the sole production streaming caller (`server/video_worker.go`) uses the unbounded client, so video is not capped.

## Minor known behavior (matches Advanced, not a regression)

On the streaming path, the pre-body phase (dial/TLS/response-header wait) is bounded only by ctx, not a wall-clock timer — identical to Advanced and moot over the loopback Consul-mesh sidecar; the header-wait phase was already unbounded on the old CE streaming path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
