### PR TITLE
fix(health): make /health/ready/ self-only

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -158,7 +158,7 @@
           "200": {
             "description": "OK"
           },
-          "429": {
+          "default": {
             "content": {
               "application/json": {
                 "schema": {
@@ -166,17 +166,7 @@
                 }
               }
             },
-            "description": "Too Many Requests"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FastAPIError"
-                }
-              }
-            },
-            "description": "Internal Server Error"
+            "description": "Error"
           }
         },
         "summary": "Readiness Probe",

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -107,18 +107,12 @@ paths:
       responses:
         "200":
           description: OK
-        "429":
+        default:
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/FastAPIError"
-          description: Too Many Requests
-        "500":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/FastAPIError"
-          description: Internal Server Error
+          description: Error
       summary: Readiness Probe
       tags:
         - health

--- a/server/api.go
+++ b/server/api.go
@@ -443,16 +443,12 @@ func buildGetHealthLive() func(context.Context, *struct{}) (*apispec.HealthLiveO
 
 func buildGetHealthReady(deps Deps) func(context.Context, *struct{}) (*apispec.HealthReadyOutput, error) {
 	return func(ctx context.Context, _ *struct{}) (*apispec.HealthReadyOutput, error) {
-		cfg := deps.Cfg
-		if cfg == nil || !cfg.AreDocsEnabled {
-			return &apispec.HealthReadyOutput{}, nil
-		}
-		if isDependencyUp(cfg.DocumentConversionFullServiceAddress) {
-			return &apispec.HealthReadyOutput{}, nil
-		}
-		// Return 429 via huma error — huma will write the status; the body
-		// will be plain text matching the legacy handler.
-		return nil, huma.NewError(http.StatusTooManyRequests, config.Msg.DocsEditorUnavailable)
+		// Readiness reports only whether this service itself is up; it must
+		// not probe dependencies. carbonio-docs-editor and carbonio-storages
+		// are OPTIONAL and reported for information by GET /health/. This
+		// mirrors GET /health/live/ and the carbonio-tasks health pattern
+		// (gate on liveness; never fail health on a dependency being down).
+		return &apispec.HealthReadyOutput{}, nil
 	}
 }
 

--- a/server/apispec/register.go
+++ b/server/apispec/register.go
@@ -195,7 +195,6 @@ func RegisterHealthOps(
 		Summary:       "Readiness Probe",
 		Tags:          []string{"health"},
 		DefaultStatus: http.StatusOK,
-		Errors:        []int{429},
 	}, getReady)
 
 	// GET /health/

--- a/server/health_test.go
+++ b/server/health_test.go
@@ -90,9 +90,11 @@ func TestHealthReady_DocsUp(t *testing.T) {
 	}
 }
 
-// TestHealthReady_DocsDown verifies that /health/ready/ returns 429 with the
-// DocsEditorUnavailable message when docs-editor is unreachable.
-func TestHealthReady_DocsDown(t *testing.T) {
+// TestHealthReady_SelfOnly_DocsDownStillReady verifies that /health/ready/
+// reports readiness based only on this service's own status: even when the
+// OPTIONAL docs-editor dependency is unreachable, readiness must still return
+// 200. Dependency states remain visible for information via GET /health/.
+func TestHealthReady_SelfOnly_DocsDownStillReady(t *testing.T) {
 	// Use a server that is immediately closed (connection refused).
 	docs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	docs.Close()
@@ -102,11 +104,8 @@ func TestHealthReady_DocsDown(t *testing.T) {
 
 	rec := doRequest(mux, http.MethodGet, "/health/ready/")
 
-	if rec.Code != http.StatusTooManyRequests {
-		t.Errorf("status: got %d, want 429", rec.Code)
-	}
-	if !strings.Contains(rec.Body.String(), config.Msg.DocsEditorUnavailable) {
-		t.Errorf("body %q does not contain %q", rec.Body.String(), config.Msg.DocsEditorUnavailable)
+	if rec.Code != http.StatusOK {
+		t.Errorf("status: got %d, want 200", rec.Code)
 	}
 }
 

--- a/server/static/openapi.json
+++ b/server/static/openapi.json
@@ -158,7 +158,7 @@
           "200": {
             "description": "OK"
           },
-          "429": {
+          "default": {
             "content": {
               "application/json": {
                 "schema": {
@@ -166,17 +166,7 @@
                 }
               }
             },
-            "description": "Too Many Requests"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FastAPIError"
-                }
-              }
-            },
-            "description": "Internal Server Error"
+            "description": "Error"
           }
         },
         "summary": "Readiness Probe",


### PR DESCRIPTION
## Problem

`GET /health/ready/` returned **429 Too Many Requests** whenever the OPTIONAL `carbonio-docs-editor` dependency was unreachable, even though:

- `GET /health/` already reports `ready: true` unconditionally and lists `carbonio-docs-editor` / `carbonio-storages` as `OPTIONAL` dependencies, for information.
- Image and PDF previews work fine without docs-editor — it's only needed for document conversion.
- Standard readiness-probe semantics are "can this service serve traffic", not "are all optional integrations reachable". Gating readiness on an optional dependency causes orchestrators/consumers to treat a fully-functional instance as not-ready.

## Fix

`buildGetHealthReady` in `server/api.go` no longer probes any dependency. It now always reports the service itself is up, exactly like `GET /health/live/` — mirroring the `carbonio-tasks` health pattern (gate on liveness, never fail health because an optional dependency is down).

`GET /health/` is untouched and continues to report `carbonio-docs-editor` / `carbonio-storages` status for information.

The huma operation for `/health/ready/` no longer declares `429` in its `Errors` list (it can no longer return that status), and the OpenAPI docs (`docs/openapi.yaml`, `docs/openapi.json`, `server/static/openapi.json`) were regenerated via `go generate ./server/...` so the spec matches reality.

## Impact

Consumers of `/health/ready/` — e.g. WSC's `previewer_service` — will now see readiness reflect what the service can actually do, instead of flapping to not-ready when an optional, non-blocking dependency has a hiccup.

## Testing

- `TestHealthReady_DocsDown` renamed to `TestHealthReady_SelfOnly_DocsDownStillReady` and updated to assert `200 OK` (previously asserted `429`).
- `TestHealthReady_DocsUp` and `TestHealthReady_DocsDisabled` still pass.
- `go build ./...`, `go vet ./...`, `gofmt -l` (Go files), and `go test ./...` (including the `docs` OpenAPI-drift package) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VvT7bkDtuwUA4TVmVrenZR