### PR TITLE
chore(packaging): migrate yap build images to v2.4

### DIFF
--- a/docker/packaging/Dockerfile
+++ b/docker/packaging/Dockerfile
@@ -21,31 +21,36 @@ RUN mkdir -p staging && \
     { [ -f README.md ] && cp README.md staging/ || true; }
 
 # Stage Ubuntu 20.04 (Focal)
+# yap-ubuntu-focal has no v2 image upstream; kept on 1.x intentionally
 FROM docker.io/m0rf30/yap-ubuntu-focal:1.55 AS ubuntu-focal-builder
 WORKDIR /tmp/staging
 COPY --from=prep /staging/staging .
 RUN yap build ubuntu-focal /tmp/staging/package
 
 # Stage Ubuntu 22.04 (Jammy)
-FROM docker.io/m0rf30/yap-ubuntu-jammy:1.55 AS ubuntu-jammy-builder
+FROM docker.io/m0rf30/yap-ubuntu-jammy:2.4 AS ubuntu-jammy-builder
+USER root
 WORKDIR /tmp/staging
 COPY --from=prep /staging/staging .
 RUN yap build ubuntu-jammy /tmp/staging/package
 
 # Stage Ubuntu 24.04 (Noble)
-FROM docker.io/m0rf30/yap-ubuntu-noble:1.55 AS ubuntu-noble-builder
+FROM docker.io/m0rf30/yap-ubuntu-noble:2.4 AS ubuntu-noble-builder
+USER root
 WORKDIR /tmp/staging
 COPY --from=prep /staging/staging .
 RUN yap build ubuntu-noble /tmp/staging/package
 
 # Stage RHEL/Rocky 8
-FROM docker.io/m0rf30/yap-rocky-8:1.55 AS rocky-8-builder
+FROM docker.io/m0rf30/yap-rocky-8:2.4 AS rocky-8-builder
+USER root
 WORKDIR /tmp/staging
 COPY --from=prep /staging/staging .
 RUN yap build rocky-8 /tmp/staging/package
 
 # Stage RHEL/Rocky 9
-FROM docker.io/m0rf30/yap-rocky-9:1.55 AS rocky-9-builder
+FROM docker.io/m0rf30/yap-rocky-9:2.4 AS rocky-9-builder
+USER root
 WORKDIR /tmp/staging
 COPY --from=prep /staging/staging .
 RUN yap build rocky-9 /tmp/staging/package


### PR DESCRIPTION
## Rationale

Renovate proposed a straight `yap-*:1.55 -> 2.4` tag-swap for the packaging build stages in `docker/packaging/Dockerfile`. Applying that swap as-is breaks the build: the yap v2 base images run as a non-root user by default, so yap's fakeroot `package()` step fails with `op=RunScriptInFakeroot` (fakeroot cannot escalate privileges from a non-root uid inside the container).

## Fix

Add `USER root` immediately after each `FROM ... AS <stage>` for the v2 build stages, restoring the capability yap's fakeroot step needs. This is an artifact-agnostic fix at the yap/container level — it does not touch how packages are built.

- `ubuntu-jammy-builder`, `ubuntu-noble-builder`, `rocky-8-builder`, `rocky-9-builder` -> bumped to `m0rf30/yap-<distro>:2.4` + `USER root`.
- `ubuntu-focal-builder` -> left on `1.55`; there is no `2.4` image published upstream for `yap-ubuntu-focal` (confirmed via `docker manifest inspect`, image not found). Left intentionally on 1.x with an explanatory comment above the stage.
- Final `alpine` collection stage is untouched (not a yap stage).

The Go build itself (cgo, libvips, pdfium, Go toolchain download) happens inside the yap container via `package/PKGBUILD` and is completely orthogonal to this change — the stage/tag/USER swap does not touch the build recipe.

## Validation

A full local build here is heavy (Go toolchain + cgo/libvips/pdfium download inside each yap container) and was not attempted. Validated instead via:
- `docker manifest inspect` confirms all 4 non-focal `yap-*:2.4` images exist upstream (`ubuntu-jammy`, `ubuntu-noble`, `rocky-8`, `rocky-9`).
- `docker manifest inspect` confirms `yap-ubuntu-focal:2.4` does **not** exist, justifying keeping focal on `1.55`.
- Dockerfile re-read/diff to confirm only the intended stages changed.

The real build is validated by Jenkins CI on this PR.

## Proof of pattern

This is the same `USER root` fix already validated cross-repo:
- `carbonio-tasks-ce`: A/B control test proving the fakeroot failure is fixed by `USER root` on the v2 stage.
- `carbonio-user-management`: full smoke test of the same migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
